### PR TITLE
Fix/windows build run issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "preswald",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "preswald",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/preswald/engine/runner.py
+++ b/preswald/engine/runner.py
@@ -1,3 +1,4 @@
+import os
 import asyncio
 import logging
 import sys
@@ -224,11 +225,18 @@ class ScriptRunner:
             # Capture script output
             with self._redirect_stdout():
                 # Execute script
-                with open(self.script_path, "r") as f:
+                with open(self.script_path, "r", encoding='utf-8') as f:
+                    # Save current cwd
+                    current_working_dir = os.getcwd()
+                    # Execute script with script directory set as cwd
+                    script_dir = os.path.dirname(os.path.realpath(self.script_path))
+                    os.chdir(script_dir)
                     code = compile(f.read(), self.script_path, "exec")
                     logger.debug("[ScriptRunner] Script compiled")
                     exec(code, self._script_globals)
                     logger.debug("[ScriptRunner] Script executed")
+                    # Change back to original working dir
+                    os.chdir(current_working_dir)
 
                 # Process rendered components
                 service = PreswaldService.get_instance()

--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,13 @@ class BuildFrontendCommand(Command):
 
         print("Building frontend assets...")
         try:
+            # Obtain npm path 
+            npm_path = shutil.which("npm")
+            if not npm_path: 
+                raise Exception("npm is not installed or not found in PATH")
             # Run npm install with error handling
             result = subprocess.run(
-                ["npm", "install"],
+                [npm_path, "install"],
                 cwd=frontend_dir,
                 capture_output=True,
                 text=True,
@@ -45,7 +49,7 @@ class BuildFrontendCommand(Command):
 
             # Run npm build with error handling
             result = subprocess.run(
-                ["npm", "run", "build"],
+                [npm_path, "run", "build"],
                 cwd=frontend_dir,
                 capture_output=True,
                 text=True,
@@ -137,7 +141,7 @@ setup(
     author="Structured",
     author_email="founders@structuredlabs.com",
     description="A lightweight data workflow SDK.",
-    long_description=open("README.md").read(),
+    long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     url="https://github.com/StructuredLabs/preswald",
     license="Apache License 2.0",


### PR DESCRIPTION
fix: issues occurring when building and running Preswald on Windows

This PR ensures: 
- README.md and example scripts (hello.py) are opened using utf-8.
- The npm path is obtained using shutil.which() to avoid lack of path availability when running a subprocess command.
- The current working directory is set to the script location using os.chdir() before running the example script. 

Fixes #65 
Fixes #59