### PR TITLE
Fix/frontend cleanup

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,8 +1,0 @@
-# React + Vite
-
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
-
-Currently, two official plugins are available:
-
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,8 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "lint": "eslint . --ext .js,.jsx",
-    "lint:fix": "eslint . --ext .js,.jsx --fix",
+		"lint": "eslint .",
+		"lint:fix": "eslint . --fix",
     "format": "prettier --write '**/*.{js,jsx,css,scss,json}'"
   },
   "dependencies": {


### PR DESCRIPTION
fix: Deletes template README and corrects `npm run lint` command

This PR deletes the generic Vite template project README and deletes the flag that was causing the following error on running `npm run lint`. Line 18 eslint.config.js already specifies the target extensions.

```
Invalid option '--ext' - perhaps you meant '-c'?
You're using eslint.config.js, some command line flags are no longer available. Please see https://eslint.org/docs/latest/use/command-line-interface for details. 
```

Doesn't fix #40, but I encountered this issue while starting on a fix.