### PR TITLE
[Cleanup] Reemove isort and use only ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,12 +7,6 @@ repos:
         language: system
         types: [python]
 
-      - id: isort
-        name: isort
-        entry: isort
-        language: system
-        types: [python]
-
       - id: ruff
         name: ruff
         entry: ruff check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,19 +17,6 @@ extend-exclude = '''
 )
 '''
 
-# isort configuration - made compatible with Black
-[tool.isort]
-profile = "black"
-multi_line_output = 3
-line_length = 88
-force_grid_wrap = 0
-include_trailing_comma = true
-use_parentheses = true
-ensure_newline_before_comments = true
-split_on_trailing_comma = true
-# Skip frontend-related directories
-skip = ["frontend", "dist", "build", ".eggs"]
-
 # Ruff configuration
 [tool.ruff]
 line-length = 88
@@ -80,3 +67,9 @@ max-complexity = 12  # Slightly higher than default to accommodate your build co
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"  # Using Google style docstrings
+
+[tool.ruff.lint.isort]
+lines-after-imports = 2
+known-first-party = []  # Add your project's modules here
+known-third-party = []  # Add specific third-party modules here if needed
+section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]

--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,9 @@ class BuildFrontendCommand(Command):
 
         print("Building frontend assets...")
         try:
-            # Obtain npm path 
+            # Obtain npm path
             npm_path = shutil.which("npm")
-            if not npm_path: 
+            if not npm_path:
                 raise Exception("npm is not installed or not found in PATH")
             # Run npm install with error handling
             result = subprocess.run(
@@ -131,7 +131,6 @@ CORE_DEPENDENCIES = [
 DEV_DEPENDENCIES = [
     "pytest>=8.3",
     "build",
-    "isort",
     "twine",
     "black>=23.12.1",
     "ruff>=0.1.11",


### PR DESCRIPTION
**Description of Changes**
Remove use of `isort` for import sorting, and instead just using `ruff` with additional config.

**Why:**
`isort was conflicting with `ruff`

**Testing**
Ran pre-commit hooks and verified that everything was working without `isort`
<img width="637" alt="Screenshot 2025-02-09 at 10 45 17 PM" src="https://github.com/user-attachments/assets/be4d21b4-4e72-4d54-b108-b3b4f55f6435" />