### PR TITLE
Add `data/` dir, `sample.csv`, and default Plotly chart to `preswald_init`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,12 +7,6 @@ repos:
         language: system
         types: [python]
 
-      - id: isort
-        name: isort
-        entry: isort
-        language: system
-        types: [python]
-
       - id: ruff
         name: ruff
         entry: ruff check

--- a/preswald/cli.py
+++ b/preswald/cli.py
@@ -37,6 +37,7 @@ def init(name):
     try:
         os.makedirs(name, exist_ok=True)
         os.makedirs(os.path.join(name, "images"), exist_ok=True)
+        os.makedirs(os.path.join(name, "data"), exist_ok=True)
 
         # Copy default branding files from package resources
         import shutil
@@ -55,6 +56,7 @@ def init(name):
             ".gitignore": "gitignore",
             "README.md": "readme.md",
             "pyproject.toml": "pyproject.toml",
+            "data/sample.csv": "sample.csv",
         }
 
         for file_name, template_name in file_templates.items():
@@ -209,7 +211,7 @@ def deploy(script, target, port, log_level):
         else:
             url = deploy_app(script, target, port=port)
 
-            ## Deployment Success Message
+            # Deployment Success Message
             success_message = f"""
 
             ===========================================================\n

--- a/preswald/templates/hello.py.template
+++ b/preswald/templates/hello.py.template
@@ -1,4 +1,26 @@
-from preswald import text
+from preswald import text, plotly, view
+import pandas as pd
+import plotly.express as px
 
 text("# Welcome to Preswald!")
 text("This is your first app. 🎉")
+
+# Load the CSV
+df = pd.read_csv('data/sample.csv')
+
+# Create a scatter plot
+fig = px.scatter(df, x='quantity', y='value', text='item',
+                 title='Quantity vs. Value',
+                 labels={'quantity': 'Quantity', 'value': 'Value'})
+
+# Add labels for each point
+fig.update_traces(textposition='top center', marker=dict(size=12, color='lightblue'))
+
+# Style the plot
+fig.update_layout(template='plotly_white')
+
+# Show the plot
+plotly(fig)
+
+# Show the data
+view(df)

--- a/preswald/templates/preswald.toml.template
+++ b/preswald/templates/preswald.toml.template
@@ -9,12 +9,8 @@ logo = "images/logo.png"
 favicon = "images/favicon.ico"
 primaryColor = "#F89613"
 
-[data.postgres]
-host = "localhost"            # PostgreSQL host
-port = 5432                   # PostgreSQL port
-dbname = "mydb"              # Database name
-user = "user"                # Username
-# password is stored in secrets.toml
+[data.csv]
+file_path = "data/sample.csv"
 
 [logging]
 level = "INFO"  # Options: DEBUG, INFO, WARNING, ERROR, CRITICAL


### PR DESCRIPTION
- Running `preswald_init` now gives users a ready-to-go example with data and visuals, no extra setup needed.
- 
**What Changed:**  
- When you run `preswald_init`, it now:
  - Creates a `data/` directory.
  - Drops in a `sample.csv` file.
  - Auto-generates a basic Plotly scatter plot using that CSV.

**Details:**
1. **Directory & File Additions:**
   - `data/` dir gets created alongside `images/`.
   - `sample.csv` gets copied into `data/` on init.

2. **Plot Setup:**
   - Updated `hello.py.template` to load `sample.csv` and plot `Quantity vs. Value` using Plotly Express.
   - The plot has labeled points, light blue markers, and a clean white background.
   - Also displays the DataFrame below the plot using `view(df)`.

3. **Config Tweaks:**
   - Removed PostgreSQL config from `preswald.toml.template`.
   - Added simple CSV config (`file_path = "data/sample.csv"`).

![Screenshot 2025-02-09 at 10 46 22 PM](https://github.com/user-attachments/assets/d0352903-3ad4-4d27-a1e7-3b6c3fad8a16)
