### PR TITLE
Fix port printing issue

### DIFF
--- a/preswald/cli.py
+++ b/preswald/cli.py
@@ -10,7 +10,7 @@ from preswald.deploy import cleanup_gcp_deployment, stop_structured_deployment
 from preswald.deploy import deploy as deploy_app
 from preswald.deploy import stop as stop_app
 from preswald.main import start_server
-from preswald.utils import configure_logging, read_template
+from preswald.utils import configure_logging, read_port_from_config, read_template
 
 
 # Create a temporary directory for IPC
@@ -99,6 +99,7 @@ def run(script, port, log_level, disable_new_tab):
 
     config_path = os.path.join(os.path.dirname(script), "preswald.toml")
     log_level = configure_logging(config_path=config_path, level=log_level)
+    port = read_port_from_config(config_path=config_path, port=port)
 
     url = f"http://localhost:{port}"
     click.echo(f"Running '{script}' on {url} with log level {log_level}  🎉!")
@@ -111,6 +112,7 @@ def run(script, port, log_level, disable_new_tab):
 
     except Exception as e:
         click.echo(f"Error: {e}")
+
 
 @cli.command()
 @click.argument("script", default="app.py")
@@ -156,11 +158,14 @@ def deploy(script, target, port, log_level, github, api_key):
 
         config_path = os.path.join(os.path.dirname(script), "preswald.toml")
         log_level = configure_logging(config_path=config_path, level=log_level)
+        port = read_port_from_config(config_path=config_path, port=port)
 
         if target == "structured":
             click.echo("Starting production deployment... 🚀")
             try:
-                for status_update in deploy_app(script, target, port=port, github_username=github, api_key=api_key):
+                for status_update in deploy_app(
+                    script, target, port=port, github_username=github, api_key=api_key
+                ):
                     status = status_update.get("status", "")
                     message = status_update.get("message", "")
 
@@ -340,6 +345,7 @@ def tutorial(ctx):
     This command runs the tutorial app located in the package's tutorial directory.
     """
     import preswald
+
     package_dir = os.path.dirname(preswald.__file__)
     tutorial_script = os.path.join(package_dir, "tutorial", "hello.py")
 

--- a/preswald/main.py
+++ b/preswald/main.py
@@ -18,6 +18,7 @@ from preswald.engine.service import PreswaldService
 
 logger = logging.getLogger(__name__)
 
+
 def create_app(script_path: Optional[str] = None) -> FastAPI:
     """Create and configure the FastAPI application"""
     app = FastAPI()
@@ -82,6 +83,7 @@ def _register_static_routes(app: FastAPI):
         """Serve the SPA for any other routes"""
         return await serve_index()
 
+
 def _register_websocket_routes(app: FastAPI):
     """Register WebSocket routes"""
 
@@ -114,20 +116,6 @@ def _register_routes(app: FastAPI):
 def start_server(script: Optional[str] = None, port: int = 8501):
     """Start the FastAPI server"""
     app = create_app(script)
-
-    # Load port from config if available
-    if script:
-        try:
-            script_dir = os.path.dirname(script)
-            config_path = os.path.join(script_dir, "preswald.toml")
-            if os.path.exists(config_path):
-                import toml
-
-                config = toml.load(config_path)
-                if "project" in config and "port" in config["project"]:
-                    port = config["project"]["port"]
-        except Exception as e:
-            logger.error(f"Error loading config: {e}")
 
     config = uvicorn.Config(app, host="0.0.0.0", port=port, loop="asyncio")
     server = uvicorn.Server(config)

--- a/preswald/utils.py
+++ b/preswald/utils.py
@@ -1,9 +1,9 @@
 import logging
-import toml
 import os
-import pkg_resources
 from typing import Optional
-import logging
+
+import pkg_resources
+import toml
 
 
 def read_template(template_name):
@@ -11,8 +11,19 @@ def read_template(template_name):
     template_path = pkg_resources.resource_filename(
         "preswald", f"templates/{template_name}.template"
     )
-    with open(template_path, "r") as f:
+    with open(template_path) as f:
         return f.read()
+
+
+def read_port_from_config(config_path: str, port: int):
+    try:
+        if os.path.exists(config_path):
+            config = toml.load(config_path)
+            if "project" in config and "port" in config["project"]:
+                port = config["project"]["port"]
+        return port
+    except Exception as e:
+        print(f"Warning: Could not load port config from {config_path}: {e}")
 
 
 def configure_logging(config_path: Optional[str] = None, level: Optional[str] = None):


### PR DESCRIPTION
preswald.toml port config takes precedence over cli argument. but, cli was still printing the cli argument for port (using the preswald.toml behind the scenes)

this fixes the printing mismatch.