### PR TITLE
fix: resolve gcp depl

### DIFF
--- a/docker/preswald_app.Dockerfile
+++ b/docker/preswald_app.Dockerfile
@@ -36,7 +36,7 @@ RUN chown -R preswald:preswald /app
 
 USER preswald
 
-COPY --chown=preswald:preswald docker/entrypoint.sh /entrypoint.sh
+COPY --chown=preswald:preswald entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 ENV HOST=0.0.0.0

--- a/docker/test/voice_app.Dockerfile
+++ b/docker/test/voice_app.Dockerfile
@@ -1,3 +1,3 @@
-FROM preswald-base:latest
+FROM structuredlabs/preswald-base:latest
 
 COPY ../../examples/voice /app/project/


### PR DESCRIPTION
```
(preswald) jayanth.kumar@Jayanths-MacBook-Pro voice % preswald deploy --target gcp                                  

Using Google Cloud project: structured-app-prod

Building Docker image preswald-app-voice-log-debugger for GCP deployment...
Running build command in /Users/jayanth.kumar/Downloads/work/structuredLabs/preswald/examples/voice/.preswald_deploy: docker buildx build --platform linux/amd64 -t preswald-app-voice-log-debugger --load .
[+] Building 7.3s (9/9) FINISHED                                                           docker-container:happy_jang
 => [internal] load build definition from Dockerfile                                                              0.0s
 => => transferring dockerfile: 135B                                                                              0.0s
 => [internal] load metadata for docker.io/structuredlabs/preswald-base:latest                                    2.0s
 => [auth] structuredlabs/preswald-base:pull token for registry-1.docker.io                                       0.0s
 => [internal] load .dockerignore                                                                                 0.0s
 => => transferring context: 2B                                                                                   0.0s
 => [internal] load build context                                                                                 0.0s
 => => transferring context: 1.40kB                                                                               0.0s
 => [1/2] FROM docker.io/structuredlabs/preswald-base:latest@sha256:7e9b52cb65c3fce2e3c112964c7a9dfa72970f2d3061  2.4s
 => => resolve docker.io/structuredlabs/preswald-base:latest@sha256:7e9b52cb65c3fce2e3c112964c7a9dfa72970f2d3061  0.0s
 => => sha256:8461455975c6c9a72e2219908bfc93423e3ba5aedde09002ec759739a4a88f47 31.45MB / 31.45MB                  2.3s
 => [2/2] COPY . /app/project                                                                                     0.1s
 => exporting to docker image format                                                                              4.9s
 => => exporting layers                                                                                           0.0s
 => => exporting manifest sha256:0f5fa0d8125e343fd4ab05267da8076136affdc69cad1c7b000e5071a1cb0867                 0.0s
 => => exporting config sha256:505f7b67373398117b9045c8e20b136c937bcf2f6681d2531099a0e96257994f                   0.0s
 => => sending tarball                                                                                            2.5s
 => importing to docker                                                                                           0.1s
 => => loading layer 08a1c8951cf4 32.77kB / 95.72kB                                                               0.1s

View build details: docker-desktop://dashboard/build/happy_jang/happy_jang0/rf7fnod7r2bxkh2802zzelgo8

Pushing image to Google Container Registry...
Using default tag: latest
The push refers to repository [gcr.io/structured-app-prod/preswald-app-voice-log-debugger]
08a1c8951cf4: Pushed 
daec366f9634: Pushed 
40d4ee22a884: Layer already exists 
7662a8a9eaff: Pushed 
2750ce7374b8: Pushed 
04b06ad32dbc: Pushed 
936be9f37c6c: Pushed 
5e7c030ae937: Pushed 
a935e92d1c25: Layer already exists 
97ae8698d80f: Layer already exists 
b3132833b4ac: Layer already exists 
6c57c16cc4ca: Layer already exists 
f18e387e49b4: Layer already exists 
f114047a243d: Layer already exists 
latest: digest: sha256:a180b6d828f2e381968de5b81ea68b3ba1f6ada5f3f2f1f0c80d409b71c78c08 size: 3243

Deploying to Cloud Run...


✨ Successfully deployed to: https://preswald-app-voice-log-debugger-ndjz2ws6la-uw.a.run.app


            ===========================================================

            🎉 Deployment successful! ✅

            🌐 Your app is live and running at:
            https://preswald-app-voice-log-debugger-ndjz2ws6la-uw.a.run.app

            💡 Next Steps:
                - Open the URL above in your browser to view your app

            🚀 Deployment Summary:
                - App: hello.py
                - Environment: gcp
                - Port: 8080
            
(preswald) jayanth.kumar@Jayanths-MacBook-Pro voice % ```