### PR TITLE
Spotify Streams Analysis 

### DIFF
--- a/community_gallery/spotify_streams_analysis/community_gallery/spotify_streams_analysis/README.md
+++ b/community_gallery/spotify_streams_analysis/community_gallery/spotify_streams_analysis/README.md
@@ -1,0 +1,46 @@
+# Spotify Streams Analysis
+
+This app analyzes the most streamed songs on Spotify in 2024. It provides insights into top artists, tracks, and trends using interactive visualizations.
+
+## Dataset Source
+The dataset used in this app contains information about Spotify streams, YouTube views, and other metrics for popular tracks.  
+- **Source**: [Link to dataset] (if applicable)
+- **File**: `data/Most_Streamed_Spotify_Songs_2024_utf8.csv`
+
+## What the App Does
+The app includes:
+- A bar chart showing the top artists by Spotify streams.
+- A scatter plot comparing Spotify streams vs YouTube views.
+- A slider to filter songs based on stream counts.
+- Key metrics like total streams, total tracks, and the top-performing track.
+
+## How to Run the App
+1. Clone this repository:
+   ```bash
+   git clone https://github.com/<your-github-username>/Preswald.git
+   cd Preswald/community_gallery/spotify_streams_analysis
+Install dependencies:
+bash
+Copy
+1
+pip install preswald
+Run the app locally:
+bash
+Copy
+1
+preswald run hello.py
+ How to Deploy the App
+
+To deploy the app to Structured Cloud:
+Install Preswald:
+bash
+Copy
+1
+pip install preswald
+Deploy the app:
+bash
+Copy
+1
+preswald deploy --target structured --github <your-github-username> --api-key <structured-api-key> hello.py
+
+

--- a/community_gallery/spotify_streams_analysis/community_gallery/spotify_streams_analysis/README.md
+++ b/community_gallery/spotify_streams_analysis/community_gallery/spotify_streams_analysis/README.md
@@ -4,7 +4,6 @@ This app analyzes the most streamed songs on Spotify in 2024. It provides insigh
 
 ## Dataset Source
 The dataset used in this app contains information about Spotify streams, YouTube views, and other metrics for popular tracks.  
-- **Source**: [Link to dataset] (if applicable)
 - **File**: `data/Most_Streamed_Spotify_Songs_2024_utf8.csv`
 
 ## What the App Does

--- a/community_gallery/spotify_streams_analysis/community_gallery/spotify_streams_analysis/hello.py
+++ b/community_gallery/spotify_streams_analysis/community_gallery/spotify_streams_analysis/hello.py
@@ -1,0 +1,74 @@
+from preswald import text, table, plotly, connect, get_df, slider
+import pandas as pd
+import plotly.express as px
+
+# Welcome Message
+text("# Spotify Streams Analysis App 🎵")
+text("Analyze the most streamed songs on Spotify in 2024.")
+
+# Initialize connection to preswald.toml data sources
+connect()
+
+
+df = get_df("Most_Streamed_Spotify_Songs_2024")
+
+
+if df is None:
+    text("Error: Dataset could not be loaded. Check the dataset name and path.")
+else:
+    text("Dataset loaded successfully!")
+
+    
+    df["Spotify Streams"] = df["Spotify Streams"].str.replace(",", "", regex=True).apply(pd.to_numeric, errors="coerce")
+    df["YouTube Views"] = df["YouTube Views"].str.replace(",", "", regex=True).apply(pd.to_numeric, errors="coerce")
+    df = df.dropna(subset=["Spotify Streams", "YouTube Views"])
+
+    # Display Key Metrics
+    total_streams = df["Spotify Streams"].sum()
+    total_tracks = len(df)
+    top_track = df.loc[df["Spotify Streams"].idxmax()]["Track"]
+    top_artist = df.loc[df["Spotify Streams"].idxmax()]["Artist"]
+
+    text("""
+    ### Key Metrics 📊
+    - Total Streams: {:,.0f}
+    - Total Tracks: {}
+    - Top Track: {} by {}
+    """.format(total_streams, total_tracks, top_track, top_artist))
+
+    # Add User Controls: Stream Threshold Slider
+    threshold = slider("Stream Threshold", min_val=0, max_val=2500000000, default=500000000)
+
+    # Filter Data Based on User Input
+    filtered_df = df[df["Spotify Streams"] > threshold]
+
+    # Display Filtered Data in a Table
+    table(filtered_df, title="Top Streamed Songs (Filtered)")
+
+    # Top Artists by Streams (Bar Chart)
+    top_artists = filtered_df.groupby("Artist")["Spotify Streams"].sum().nlargest(10).reset_index()
+    fig_bar = px.bar(
+        top_artists,
+        x="Artist",
+        y="Spotify Streams",
+        title="Top Artists by Spotify Streams",
+        labels={"Spotify Streams": "Total Streams"},
+        color="Spotify Streams",
+        color_continuous_scale="Viridis"
+    )
+    fig_bar.update_layout(template="plotly_white")
+    plotly(fig_bar)
+
+    # Scatter Plot: Spotify Streams vs YouTube Views
+    fig_scatter = px.scatter(
+        filtered_df,
+        x="Spotify Streams",
+        y="YouTube Views",
+        color="Artist",
+        hover_name="Track",
+        title="Spotify Streams vs YouTube Views by Artist",
+        labels={"Spotify Streams": "Total Spotify Streams", "YouTube Views": "YouTube Views"},
+    )
+    fig_scatter.update_traces(marker=dict(size=10, opacity=0.8))
+    fig_scatter.update_layout(template="plotly_white")
+    plotly(fig_scatter)


### PR DESCRIPTION
Added Spotify Streams Analysis example to community_gallery.

This app analyzes the most streamed songs on Spotify in 2024. It includes:
- A bar chart showing top artists by streams.
- A scatter plot comparing Spotify streams vs YouTube views.
- Interactive filtering with a slider.
- Key metrics like total streams and top-performing track.

The dataset is included in the `data/` folder, and instructions for running and deploying the app are provided in the README.md file.
