### PR TITLE
Fix TypeError by replacing | with Union for Python 3.7+ support

### DIFF
--- a/preswald/deploy.py
+++ b/preswald/deploy.py
@@ -9,7 +9,7 @@ import zipfile
 from datetime import datetime
 from importlib.metadata import version
 from pathlib import Path
-from typing import Generator, Optional
+from typing import Union, Generator, Optional
 
 import requests
 import toml
@@ -634,7 +634,21 @@ def deploy(  # noqa: C901
     port: int = 8501,
     github_username: Optional[str] = None,
     api_key: Optional[str] = None,
-) -> str | Generator[dict, None, None]:
+) -> Union[str , Generator[dict, None, None]]:
+    """
+    Deploy a Preswald app.
+
+    Args:
+        script_path: Path to the Preswald application script
+        target: Deployment target ("local", "gcp", "aws", or "prod")
+        port: Port number for the deployment
+        github_username: Optional GitHub username for structured deployment
+        api_key: Optional Structured Cloud API key for structured deployment
+
+    Returns:
+        str | Generator: URL where the application can be accessed for local/cloud deployments,
+                        or a Generator yielding deployment status for production deployments
+    """
     if target == "structured":
         return deploy_to_prod(script_path, port, github_username, api_key)
     elif target == "gcp":


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to contribute to the project
title: 'Fix TypeError in deploy.py for Python 3.7+ compatibility'
labels: 'bug'
assignees: ''

---

## **Related Issue**
Fixes #218   

## **Description of Changes**
This PR replaces the `|` (union operator) in `deploy.py` with `Union` from the `typing` module.  
- **Reason**: The `|` operator is only supported in Python 3.10+, while Preswald supports Python 3.7+.  
- **Fix**: Updated function return type to use `Union[...]`.  

## **Type of Change**
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (adds functionality)  
- [ ] Breaking change (existing functionality may not work as expected)  
- [ ] Documentation update  
- [ ] New example  
- [ ] Test improvement  

## **Testing**
I verified the fix by running:  
✅ `preswald init project` in a Python 3.9 environment (no TypeError).  
✅ Linted the code to ensure style consistency.  

## **Checklist**
- [x] My code follows the style guidelines of this project.  
- [x] I have performed a self-review of my own code.  
- [x] I have commented on my code, particularly in hard-to-understand areas.  
- [x] I have made corresponding changes to the documentation (if required).  
- [x] My changes generate no new warnings.  
- [x] I have run my code against examples and ensured no errors.  
- [x] Any dependent changes have been merged and published in downstream modules.  

---