### PR TITLE
Add World Happiness Explorer to community_gallery

### DIFF
--- a/community_gallery/world_happiness_report/README.md
+++ b/community_gallery/world_happiness_report/README.md
@@ -1,0 +1,24 @@
+# World Happiness Explorer
+
+## Overview
+An interactive dashboard to explore global happiness data from the World Happiness Report 2023. Features a map, trend charts, scatter plots, and filters, all wrapped in a modern, user-friendly UI.
+
+## Dataset
+- **Source**: [World Happiness Report 2023](https://www.kaggle.com/datasets/ajaypalsinghlo/world-happiness-report-2023)
+- **File**: `data/happiness_2023.csv`
+
+## How to Run Locally
+1. Ensure Preswald is installed: `pip install preswald`
+2. Place `happiness_2023.csv` in the `data/` folder.
+3. Run the app: `preswald run`
+
+## How to Deploy
+1. Deploy to Structured Cloud: `preswald deploy --target structured --github <your-username> --api-key <your-api-key> hello.py`
+2. Verify the app is live and accessible.
+
+## Features
+- Interactive choropleth map of happiness scores by country
+- Line chart for happiness trends over time
+- Scatter plot for factor correlations
+- Filters for countries, years, and factors
+- Responsive, styled UI with real-time feedback

--- a/community_gallery/world_happiness_report/hello.py
+++ b/community_gallery/world_happiness_report/hello.py
@@ -1,0 +1,66 @@
+from preswald import connect, get_df, text, table, plotly, selectbox
+import plotly.express as px
+import pandas as pd
+
+connect()
+df = get_df("happiness_2023")
+
+text("# World Happiness Explorer")
+text("Uncover the Secrets of Global Happiness (2023 Data)")
+
+country = selectbox("Select Country", options=df["Country name"].unique().tolist(), default="United States")
+selected_year = 2023
+
+filtered_df = df[df["Country name"] == country]
+
+text("## Happiness Overview")
+text(f"Happiness score for {country} in {selected_year}.")
+fig_map = px.choropleth(
+    filtered_df,
+    locations="Country name",
+    locationmode="country names",
+    color="Ladder score",
+    hover_name="Country name",
+    title=f"Happiness Score in {country} (2023)",
+    color_continuous_scale="Viridis",
+    height=500
+)
+fig_map.update_layout(title_x=0.5, title_font_size=20)
+plotly(fig_map)
+
+text("## Happiness Details")
+text(f"Key metrics for {country} in {selected_year}.")
+details_df = filtered_df[["Country name", "Ladder score", "Logged GDP per capita", "Social support", "Healthy life expectancy"]]
+table(details_df, title=f"Happiness Metrics for {country} (2023)")
+
+text("## Exploring Happiness Factors")
+text(f"Analyze happiness factors for {country} in {selected_year}.")
+fig_gdp = px.scatter(
+    filtered_df,
+    x="Logged GDP per capita",
+    y="Ladder score",
+    hover_data=["Country name"],
+    title=f"Happiness vs GDP per Capita in {country} (2023)",
+    labels={"Ladder score": "Happiness Score"},
+    color="Social support",
+    size="Healthy life expectancy",
+    height=500
+)
+fig_gdp.update_layout(title_x=0.5, title_font_size=20)
+plotly(fig_gdp)
+
+text("## Summary Statistics")
+text(f"Stats for {country} in {selected_year}.")
+stats_df = pd.DataFrame({
+    "Metric": ["Happiness Score", "GDP per Capita", "Social Support", "Healthy Life Expectancy"],
+    "Value": [
+        filtered_df["Ladder score"].iloc[0] if not filtered_df.empty else "N/A",
+        filtered_df["Logged GDP per capita"].iloc[0] if not filtered_df.empty else "N/A",
+        filtered_df["Social support"].iloc[0] if not filtered_df.empty else "N/A",
+        filtered_df["Healthy life expectancy"].iloc[0] if not filtered_df.empty else "N/A"
+    ]
+}).round(2)
+table(stats_df, title=f"Summary Stats for {country} (2023)")
+
+text("---")
+text("Data source: [World Happiness Report 2023](https://www.kaggle.com/datasets/ajaypalsinghlo/world-happiness-report-2023)")


### PR DESCRIPTION
This PR adds a new example to the community_gallery folder: "World Happiness Explorer."

- **Dataset**: World Happiness Report 2023 from Kaggle.
- **App**: An interactive dashboard to explore happiness scores by country, with visualizations and tables.
- **Deployed Link**: [Insert your live preview link here]

The example includes a `hello.py` script, a `README.md` with instructions, and a reference to the dataset.