### PR TITLE
 Move Tailwind Styles to `components.css`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,5 @@ notes.md
 .env.structured
 
 community_gallery/**/data
+
+node_modules/

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -142,10 +142,10 @@ const App = () => {
   };
 
   const LoadingState = () => (
-    <div className="flex items-center justify-center h-screen">
-      <div className="text-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
-        <p className="text-gray-600">Connecting...</p>
+    <div className="loading-container">
+      <div className="loading-content">
+        <div className="loading-spinner"></div>
+        <p className="loading-text">Connecting...</p>
       </div>
     </div>
   );

--- a/frontend/src/components.css
+++ b/frontend/src/components.css
@@ -1,0 +1,201 @@
+/* app.css */
+.topbar {
+  @apply sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 border-b bg-background px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:px-8;
+}
+
+.mobile-menu-button {
+  @apply lg:hidden;
+}
+
+.desktop-collapse-button {
+  @apply hidden lg:flex;
+}
+
+.icon-button {
+  @apply h-6 w-6 transition-transform duration-200;
+}
+
+.separator {
+  @apply h-6 lg:hidden;
+}
+
+.topbar-content {
+  @apply flex flex-1 gap-x-4 self-stretch lg:gap-x-6;
+}
+
+.branding-container {
+  @apply flex lg:hidden items-center;
+}
+
+.branding-logo {
+  @apply h-8 w-8;
+}
+
+.branding-name {
+  @apply ml-3 text-lg font-semibold;
+}
+
+.sidebar-container {
+  @apply flex grow flex-col h-full;
+}
+
+.sidebar-content {
+  @apply flex flex-col h-full justify-between;
+}
+
+.sidebar-nav {
+  @apply flex flex-col gap-y-5 w-full;
+}
+
+.sidebar-header {
+  @apply flex h-16 shrink-0 items-center;
+}
+
+.sidebar-logo {
+  @apply h-8 w-8;
+}
+
+.sidebar-title {
+  @apply ml-4 text-lg font-semibold transition-opacity duration-200;
+}
+
+.sidebar-nav-list {
+  @apply flex flex-1 flex-col;
+}
+
+.sidebar-nav-items {
+  @apply flex flex-1 flex-col gap-y-7;
+}
+
+.sidebar-nav-link {
+  @apply flex items-center gap-x-3 rounded-md px-2 py-2 text-sm font-semibold leading-6 transition-all duration-200 m-2;
+}
+
+.sidebar-nav-link-active {
+  @apply bg-accent hover:rounded-md;
+}
+
+.sidebar-nav-link-hover {
+  @apply hover:bg-accent;
+}
+
+.sidebar-icon {
+  @apply h-6 w-6 shrink-0 transition-transform duration-200;
+}
+
+.sidebar-footer {
+  @apply text-center text-sm text-gray-400 pb-2;
+}
+
+.sidebar-footer-link {
+  @apply hover:underline;
+}
+
+/* Mobile Sidebar */
+.sidebar-mobile {
+  @apply fixed inset-y-0 left-0 flex w-[280px] flex-col border-r bg-background p-0;
+}
+
+.sidebar-mobile-header {
+  @apply p-4 border-b;
+}
+
+.sidebar-mobile-title {
+  @apply flex items-center gap-2;
+}
+
+.sidebar-mobile-close-btn {
+  @apply top-4 right-4 h-8 w-8;
+}
+
+.sidebar-mobile-content {
+  @apply flex-1 overflow-hidden px-4 py-2;
+}
+
+/* Desktop Sidebar */
+.sidebar-desktop {
+  @apply hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:flex-col border-r bg-background transition-all duration-300 ease-in-out transform-gpu;
+}
+
+.sidebar-desktop-collapsed {
+  @apply lg:w-20;
+}
+
+.sidebar-desktop-expanded {
+  @apply lg:w-80;
+}
+
+.sidebar-desktop-content {
+  @apply flex-1 overflow-hidden px-4 py-2;
+}
+
+.loading-container {
+  @apply flex items-center justify-center h-screen;
+}
+
+.loading-content {
+  @apply text-center;
+}
+
+.loading-spinner {
+  @apply animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4;
+}
+
+.loading-text {
+  @apply text-gray-600;
+}
+
+.dynamiccomponent-container {
+  @apply flex flex-col w-full;
+}
+
+.dynamiccomponent-row {
+  @apply flex flex-row w-full;
+  margin-bottom: 1rem; /* Maintain inline style */
+}
+
+.dynamiccomponent-component {
+  @apply bg-background rounded-lg transition-all duration-200 hover:border-muted-foreground/20;
+  padding: 1rem; /* Maintain inline style */
+  min-width: 0; /* Prevent flex items from overflowing */
+}
+
+.dynamiccomponent-hidden {
+  @apply hidden;
+}
+
+.dynamiccomponent-separator {
+  @apply w-px bg-gray-200 my-4 mx-4 h-auto;
+}
+
+.dashboard-container {
+  @apply min-h-screen;
+}
+
+.dashboard-error {
+  @apply mb-4;
+}
+
+.dashboard-loading-container {
+  @apply flex items-center justify-center h-64;
+}
+
+.dashboard-loading-content {
+  @apply text-center space-y-4;
+}
+
+.dashboard-loading-spinner {
+  @apply animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto;
+}
+
+.dashboard-loading-text {
+  @apply text-sm text-muted-foreground;
+}
+
+.dashboard-empty {
+  @apply flex items-center justify-center h-64;
+}
+
+.dashboard-empty-text {
+  @apply text-sm text-muted-foreground;
+}

--- a/frontend/src/components.css
+++ b/frontend/src/components.css
@@ -199,3 +199,612 @@
 .dashboard-empty-text {
   @apply text-sm text-muted-foreground;
 }
+
+.alertwidget-container {
+  @apply relative flex gap-x-4 items-center p-4;
+}
+
+.alertwidget-icon {
+  @apply h-4 w-4;
+}
+
+.button-container {
+  @apply w-full sm:w-auto px-2 py-1;
+}
+
+.button-disabled {
+  @apply cursor-not-allowed;
+}
+
+.button-loading {
+  @apply flex items-center justify-center gap-2;
+}
+
+.button-spinner {
+  @apply h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent;
+}
+
+.checkbox-container {
+  @apply flex items-start space-x-3 space-y-0;
+}
+
+.checkbox-label-container {
+  @apply space-y-1 leading-none;
+}
+
+.checkbox-label {
+  @apply text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70;
+}
+
+.checkbox-description {
+  @apply text-sm text-muted-foreground;
+}
+
+.connectioninterface-card {
+  @apply w-full;
+}
+
+.connectioninterface-card-content {
+  @apply space-y-4;
+}
+
+.connectioninterface-input-group {
+  @apply space-y-2;
+}
+
+.connectioninterface-button {
+  @apply w-full;
+}
+
+.unknownwidget-container {
+  @apply border-2;
+}
+
+.unknownwidget-icon {
+  @apply h-4 w-4;
+}
+
+.unknownwidget-description {
+  @apply mt-2;
+}
+
+.unknownwidget-text {
+  @apply space-y-2 text-sm;
+}
+
+.unknownwidget-code {
+  @apply font-mono bg-muted px-1 py-0.5 rounded;
+}
+
+.unknownwidget-muted-text {
+  @apply text-muted-foreground;
+}
+
+.inputfield-container {
+  @apply space-y-2;
+}
+
+.inputfield-label {
+  @apply text-sm font-medium;
+}
+
+.inputfield-error {
+  @apply text-destructive;
+}
+
+.inputfield-disabled {
+  @apply opacity-50;
+}
+
+.inputfield-required {
+  @apply text-destructive ml-1;
+}
+
+.inputfield-size-sm {
+  @apply h-8 text-xs;
+}
+
+.inputfield-size-default {
+  @apply h-10 text-sm;
+}
+
+.inputfield-size-lg {
+  @apply h-12 text-base;
+}
+
+.inputfield-variant-ghost {
+  @apply border-none shadow-none;
+}
+
+.inputfield-error-border {
+  @apply border-destructive focus-visible:ring-destructive;
+}
+
+.inputfield-error-message {
+  @apply text-xs text-destructive mt-1;
+}
+
+.tableviewer-container {
+  @apply w-full;
+}
+
+.tableviewer-card {
+  @apply w-full;
+}
+
+.tableviewer-card-content {
+  @apply flex items-center justify-center py-6;
+}
+
+.tableviewer-no-data-text {
+  @apply text-sm text-muted-foreground;
+}
+
+.tableviewer-header {
+  @apply flex items-center justify-between mb-2;
+}
+
+.tableviewer-title {
+  @apply text-lg font-medium;
+}
+
+.tableviewer-toggle-button {
+  @apply p-0 h-9 w-9 flex items-center justify-center;
+}
+
+.tableviewer-chevron {
+  @apply h-4 w-4 transition-transform duration-200 m-auto;
+}
+
+.tableviewer-chevron-rotated {
+  @apply -rotate-90;
+}
+
+.tableviewer-table-container {
+  @apply overflow-auto transition-all duration-200 ease-in-out;
+}
+
+.tableviewer-expanded {
+  @apply opacity-100 max-h-[2000px];
+}
+
+.tableviewer-collapsed {
+  @apply opacity-0 max-h-0;
+}
+
+.tableviewer-header-cell {
+  @apply font-medium;
+}
+
+.tableviewer-row {
+  @apply cursor-pointer;
+}
+
+.tableviewer-hoverable {
+  @apply hover:bg-muted/50;
+}
+
+.tableviewer-striped {
+  @apply bg-muted/50;
+}
+
+.tableviewer-dense {
+  @apply h-8;
+}
+
+.tableviewer-normal {
+  @apply h-12;
+}
+
+.tableviewer-cell {
+  @apply p-2 md:p-4;
+}
+
+.tableviewer-cell-dense {
+  @apply py-1 text-sm;
+}
+
+.tableviewer-card-header {
+  @apply flex flex-row items-center justify-between space-y-0 pb-2;
+}
+
+.tableviewer-card-content-collapsed {
+  @apply transition-all duration-200 ease-in-out p-0 opacity-0 h-0 overflow-hidden;
+}
+
+.tableviewer-card-content-expanded {
+  @apply transition-all duration-200 ease-in-out p-0 opacity-100;
+}
+
+.spinner-container {
+  @apply flex flex-col items-center justify-center gap-3 p-4;
+}
+
+.spinner-label {
+  @apply text-sm font-medium text-muted-foreground;
+}
+
+.spinner-animation {
+  @apply rounded-full animate-spin border-primary/30 border-t-primary;
+}
+
+.spinner-size-sm {
+  @apply w-4 h-4 border-2;
+}
+
+.spinner-size-default {
+  @apply w-8 h-8 border-2;
+}
+
+.spinner-size-lg {
+  @apply w-12 h-12 border-4;
+}
+
+.spinner-card-content {
+  @apply pt-6;
+}
+
+.slider-container {
+  @apply space-y-4;
+}
+
+.slider-header {
+  @apply flex items-center justify-between;
+}
+
+.slider-label {
+  @apply text-sm font-medium;
+}
+
+.slider-label-disabled {
+  @apply opacity-50;
+}
+
+.slider-value {
+  @apply text-sm text-muted-foreground font-medium;
+}
+
+.slider-wrapper {
+  @apply p-4 bg-white;
+}
+
+.slider-track {
+  @apply w-full h-2 bg-gray-200 rounded-lg appearance-none focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2;
+}
+
+.slider-min-max {
+  @apply flex justify-between;
+}
+
+.slider-minmax-label {
+  @apply text-sm text-muted-foreground;
+}
+
+.slider-card-content {
+  @apply pt-6;
+}
+
+.progress-container {
+  @apply w-full;
+}
+
+.progress-header {
+  @apply pb-2;
+}
+
+.progress-header-content {
+  @apply flex items-center justify-between;
+}
+
+.progress-label {
+  @apply text-sm font-medium text-muted-foreground;
+}
+
+.progress-value {
+  @apply text-sm font-medium text-muted-foreground;
+}
+
+.progress-bar {
+  @apply transition-all duration-300;
+}
+
+.progress-size-sm {
+  @apply h-2;
+}
+
+.progress-size-default {
+  @apply h-3;
+}
+
+.progress-size-lg {
+  @apply h-4;
+}
+
+.progress-steps {
+  @apply mt-4 grid grid-cols-4 gap-2;
+}
+
+.progress-step {
+  @apply text-center text-sm transition-colors duration-200;
+}
+
+.progress-step-active {
+  @apply text-primary font-medium;
+}
+
+.progress-step-inactive {
+  @apply text-muted-foreground;
+}
+
+.markdown-container {
+  @apply w-full;
+}
+
+.markdown-card-variant-default {
+  @apply bg-card;
+}
+
+.markdown-card-variant-outline {
+  @apply border rounded-lg;
+}
+
+.markdown-card-variant-ghost {
+  @apply bg-transparent border-none shadow-none;
+}
+
+.markdown-card-content {
+  @apply prose prose-sm md:prose-base lg:prose-lg dark:prose-invert max-w-none;
+}
+
+.markdown-headings {
+  @apply prose-headings:scroll-m-20;
+}
+
+.markdown-paragraph {
+  @apply prose-p:leading-7;
+}
+
+.markdown-list {
+  @apply prose-li:marker:text-muted-foreground;
+}
+
+.markdown-pre {
+  @apply prose-pre:p-0 prose-pre:bg-transparent prose-pre:shadow-lg;
+}
+
+.markdown-code {
+  @apply prose-code:text-zinc-900 dark:prose-code:text-zinc-100;
+}
+
+.markdown-padding {
+  @apply p-0;
+}
+
+.markdown-heading-1 {
+  @apply scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl;
+}
+
+.markdown-heading-2 {
+  @apply scroll-m-20 pb-2 text-3xl font-semibold tracking-tight first:mt-0;
+}
+
+.markdown-heading-3 {
+  @apply scroll-m-20 text-2xl font-semibold tracking-tight;
+}
+
+.markdown-link {
+  @apply font-medium text-primary underline underline-offset-4;
+}
+
+.markdown-pre-wrapper {
+  @apply mb-2 mt-2 overflow-x-auto rounded-lg bg-zinc-950 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 p-4 shadow-sm;
+}
+
+.markdown-inline-code {
+  @apply relative rounded px-[0.3rem] py-[0.2rem] font-mono text-sm bg-zinc-100 dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 whitespace-normal inline-block;
+}
+
+.markdown-code-lang {
+  @apply absolute right-2 top-2 z-10 rounded-md bg-zinc-700 px-2 py-1 text-xs font-medium text-zinc-200;
+}
+
+.markdown-blockquote {
+  @apply mt-2 border-l-2 pl-6 italic;
+}
+
+.markdown-ul {
+  @apply my-2 ml-6 list-disc [&>li]:mt-2;
+}
+
+.markdown-ol {
+  @apply my-2 ml-6 list-decimal [&>li]:mt-2;
+}
+
+.markdown-table-wrapper {
+  @apply my-4 w-full overflow-y-auto;
+}
+
+.markdown-table {
+  @apply w-full;
+}
+
+.markdown-th {
+  @apply border px-4 py-2 text-left font-bold [&[align=center]]:text-center [&[align=right]]:text-right;
+}
+
+.markdown-td {
+  @apply border px-4 py-2 text-left [&[align=center]]:text-center [&[align=right]]:text-right;
+}
+
+.image-widget-container {
+  @apply overflow-hidden;
+}
+
+.image-widget-small {
+  @apply w-24;
+}
+
+.image-widget-medium {
+  @apply w-48;
+}
+
+.image-widget-large {
+  @apply w-96;
+}
+
+.image-widget-full {
+  @apply w-full;
+}
+
+.image-widget-img {
+  @apply h-full w-full object-cover transition-transform duration-200 hover:scale-105;
+}
+
+.image-widget-rounded {
+  @apply rounded-lg;
+}
+
+.image-widget-object-contain {
+  @apply object-contain;
+}
+
+.image-widget-card {
+  @apply p-2;
+}
+
+.plotly-container {
+  @apply w-full h-full;
+}
+
+.plotly-card-content {
+  @apply p-0;
+}
+
+.plotly-loading-container {
+  @apply flex flex-col items-center justify-center h-64;
+}
+
+.plotly-loading-spinner {
+  @apply animate-spin rounded-full h-8 w-8 border-b-2 border-primary mb-4;
+}
+
+.plotly-loading-text {
+  @apply text-sm text-muted-foreground;
+}
+
+.plotly-plot-container {
+  @apply relative w-full;
+  min-height: 400px;
+}
+
+.plotly-progress-container {
+  @apply absolute top-0 left-0 right-0 z-10 bg-background/80 backdrop-blur-sm px-4 py-2;
+}
+
+.plotly-progress-bar {
+  @apply w-full h-2;
+}
+
+.plotly-plot {
+  @apply w-full h-full;
+}
+
+.dag-visualizer-container {
+  @apply relative transition-all duration-300;
+}
+
+.dag-visualizer-fullscreen {
+  @apply fixed inset-0 z-50 m-4;
+}
+
+.dag-visualizer-error-card {
+  @apply border-red-200 bg-red-50;
+}
+
+.dag-visualizer-error-title {
+  @apply text-red-700;
+}
+
+.dag-visualizer-error-text {
+  @apply text-red-600;
+}
+
+.dag-visualizer-controls {
+  @apply absolute top-2 right-2 z-10 flex items-center gap-2;
+}
+
+.dag-visualizer-content {
+  @apply p-0;
+}
+
+.dag-visualizer-content-fullscreen {
+  @apply h-full;
+}
+
+.dag-visualizer-content-default {
+  @apply h-[600px];
+}
+
+.dag-visualizer-loading {
+  @apply flex items-center justify-center h-full;
+}
+
+.dag-visualizer-spinner {
+  @apply animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900;
+}
+
+.dag-visualizer-node-panel {
+  @apply absolute bottom-4 left-4 right-4 max-w-md mx-auto transition-all duration-300;
+}
+
+.dag-visualizer-node-panel-visible {
+  @apply opacity-100 translate-y-0;
+}
+
+.dag-visualizer-node-panel-hidden {
+  @apply opacity-0 translate-y-5;
+}
+
+.dag-visualizer-node-header {
+  @apply pb-2;
+}
+
+.dag-visualizer-node-title {
+  @apply text-lg;
+}
+
+.dag-visualizer-node-close {
+  @apply sr-only;
+}
+
+.dag-visualizer-node-details {
+  @apply space-y-3;
+}
+
+.dag-visualizer-node-status {
+  @apply flex items-center gap-2;
+}
+
+.dag-visualizer-node-status-label {
+  @apply text-sm font-medium text-muted-foreground;
+}
+
+.dag-visualizer-node-error-label {
+  @apply text-sm font-medium text-red-500;
+}
+
+.dag-visualizer-node-error-text {
+  @apply mt-1 text-sm text-red-600 bg-red-50 p-2 rounded;
+}
+
+.dag-visualizer-node-dependencies {
+  @apply mt-1 flex flex-wrap gap-1;
+}
+
+.dag-visualizer-tooltip-trigger {
+  @apply h-4 w-4;
+}
+
+.dag-visualizer-tooltip-content {
+  @apply text-xs;
+}

--- a/frontend/src/components/DynamicComponents.jsx
+++ b/frontend/src/components/DynamicComponents.jsx
@@ -284,11 +284,7 @@ const DynamicComponents = ({ components, onComponentUpdate }) => {
     }
 
     return (
-      <div
-        key={`row-${rowIndex}`}
-        className="flex flex-row w-full"
-        style={{ marginBottom: '1rem' }}
-      >
+      <div key={`row-${rowIndex}`} className="dynamiccomponent-row">
         {row.map((component, index) => {
           if (!component) return null;
 
@@ -297,14 +293,10 @@ const DynamicComponents = ({ components, onComponentUpdate }) => {
               <div
                 key={component.id || `component-${index}`}
                 className={cn(
-                  'bg-background rounded-lg transition-all duration-200 hover:border-muted-foreground/20',
-                  component.type === 'separator' ? 'hidden' : ''
+                  'dynamiccomponent-component',
+                  component.type === 'separator' && 'dynamiccomponent-hidden'
                 )}
-                style={{
-                  flex: component.flex || 1,
-                  padding: '1rem',
-                  minWidth: 0, // Prevent flex items from overflowing
-                }}
+                style={{ flex: component.flex || 1 }}
               >
                 <ErrorBoundary>
                   <MemoizedComponent
@@ -314,7 +306,7 @@ const DynamicComponents = ({ components, onComponentUpdate }) => {
                   />
                 </ErrorBoundary>
               </div>
-              {index < row.length - 1 && <div className="w-px bg-gray-200 my-4 mx-4 h-auto" />}
+              {index < row.length - 1 && <div className="dynamiccomponent-separator" />}
             </>
           );
         })}
@@ -323,7 +315,7 @@ const DynamicComponents = ({ components, onComponentUpdate }) => {
   };
 
   return (
-    <div className="flex flex-col w-full">
+    <div className="dynamiccomponent-container">
       {components.rows.map((row, index) => renderRow(row, index))}
     </div>
   );

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -22,25 +22,21 @@ export default function Sidebar({
   const primaryColor = branding?.primaryColor || '#000000';
 
   const NavContent = ({ isMobile = false }) => (
-    <div className="flex grow flex-col h-full ">
-      <div className="flex flex-col h-full justify-between">
-        <div className="flex flex-col gap-y-5 w-full">
+    <div className="sidebar-container">
+      <div className="sidebar-content">
+        <div className="sidebar-nav">
           {!isMobile && (
-            <div className="flex h-16 shrink-0 items-center">
+            <div className="sidebar-header">
               <img
-                className="h-8 w-8"
+                className="sidebar-logo"
                 src={`${branding?.logo}?timstamp=${new Date().getTime()}`}
                 alt={branding?.name}
               />
-              {!isCollapsed && (
-                <span className="ml-4 text-lg font-semibold transition-opacity duration-200">
-                  {branding?.name}
-                </span>
-              )}
+              {!isCollapsed && <span className="sidebar-title">{branding?.name}</span>}
             </div>
           )}
-          <nav className="flex flex-1 flex-col">
-            <ul role="list" className="flex flex-1 flex-col gap-y-7">
+          <nav className="sidebar-nav-list">
+            <ul role="list" className="sidebar-nav-items">
               <li>
                 <ul role="list" className="-mx-2 space-y-1">
                   {navigation.map((item) => (
@@ -49,10 +45,10 @@ export default function Sidebar({
                         to={item.href}
                         onClick={() => isMobile && setSidebarOpen(false)}
                         className={cn(
-                          'flex items-center gap-x-3 rounded-md px-2 py-2 text-sm font-semibold leading-6 transition-all duration-200 m-2',
+                          'sidebar-nav-link',
                           location.pathname === item.href
-                            ? 'bg-accent hover:rounded-md'
-                            : 'hover:bg-accent',
+                            ? 'sidebar-nav-link-active'
+                            : 'sidebar-nav-link-hover',
                           isCollapsed && !isMobile && 'justify-center px-2',
                           location.pathname === item.href
                             ? { color: primaryColor }
@@ -62,7 +58,7 @@ export default function Sidebar({
                       >
                         <item.icon
                           className={cn(
-                            'h-6 w-6 shrink-0 transition-transform duration-200',
+                            'sidebar-icon',
                             isCollapsed && !isMobile && 'transform-gpu'
                           )}
                           style={{
@@ -81,9 +77,9 @@ export default function Sidebar({
             </ul>
           </nav>
         </div>
-        <div className="text-center text-sm text-gray-400 pb-2">
+        <div className="sidebar-footer">
           Built By{' '}
-          <a href="https://github.com/structuredlabs/preswald" className="hover:underline">
+          <a href="https://github.com/structuredlabs/preswald" className="sidebar-footer-link">
             Preswald
           </a>
         </div>
@@ -95,22 +91,12 @@ export default function Sidebar({
     <>
       {/* Mobile Sidebar */}
       <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
-        <SheetContent
-          side="left"
-          className={cn(
-            'fixed inset-y-0 left-0',
-            'flex w-[280px] flex-col',
-            'border-r bg-background p-0',
-            'data-[state=closed]:duration-300 data-[state=open]:duration-500',
-            'data-[state=closed]:animate-slide-to-left data-[state=open]:animate-slide-from-left',
-            '[&>button]:top-4 [&>button]:right-4 [&>button]:h-8 [&>button]:w-8'
-          )}
-        >
-          <SheetHeader className="p-4 border-b">
+        <SheetContent side="left" className="sidebar-mobile">
+          <SheetHeader className="sidebar-mobile-header">
             <div className="flex items-center justify-between">
-              <SheetTitle className="flex items-center gap-2">
+              <SheetTitle className="sidebar-mobile-title">
                 <img
-                  className="h-8 w-8"
+                  className="sidebar-logo"
                   src={`${branding?.logo}?timstamp=${new Date().getTime()}`}
                   alt={branding?.name}
                 />
@@ -118,7 +104,7 @@ export default function Sidebar({
               </SheetTitle>
             </div>
           </SheetHeader>
-          <div className="flex-1 overflow-hidden px-4 py-2">
+          <div className="sidebar-mobile-content">
             <NavContent isMobile={true} />
           </div>
         </SheetContent>
@@ -127,12 +113,11 @@ export default function Sidebar({
       {/* Desktop Sidebar */}
       <div
         className={cn(
-          'hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:flex-col',
-          isCollapsed ? 'lg:w-20' : 'lg:w-80',
-          'border-r bg-background transition-all duration-300 ease-in-out transform-gpu'
+          'sidebar-desktop',
+          isCollapsed ? 'sidebar-desktop-collapsed' : 'sidebar-desktop-expanded'
         )}
       >
-        <div className="flex-1 overflow-hidden px-4 py-2">
+        <div className="sidebar-desktop-content">
           <NavContent />
         </div>
       </div>

--- a/frontend/src/components/TopBar.jsx
+++ b/frontend/src/components/TopBar.jsx
@@ -11,46 +11,46 @@ import { cn } from '@/lib/utils';
 
 export default function Topbar({ setSidebarOpen, branding, onToggleSidebar, isCollapsed }) {
   return (
-    <div className="sticky top-0 z-40 flex h-16 shrink-0 items-center gap-x-4 border-b bg-background px-4 shadow-sm sm:gap-x-6 sm:px-6 lg:px-8">
+    <div className="topbar">
       {/* Mobile menu button */}
       <Button
         variant="ghost"
         size="icon"
-        className="lg:hidden"
+        className="mobile-menu-button"
         onClick={() => setSidebarOpen(true)}
         aria-label="Open sidebar"
       >
-        <Menu className="h-6 w-6" />
+        <Menu className="icon-button" />
       </Button>
 
       {/* Desktop collapse button */}
       <Button
         variant="ghost"
         size="icon"
-        className="hidden lg:flex"
+        className="desktop-collapse-button"
         onClick={onToggleSidebar}
         aria-label={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
       >
         {isCollapsed ? (
-          <PanelLeft className="h-6 w-6 transition-transform duration-200" />
+          <PanelLeft className="icon-button" />
         ) : (
-          <PanelLeftClose className="h-6 w-6 transition-transform duration-200" />
+          <PanelLeftClose className="icon-button" />
         )}
       </Button>
 
       {/* Separator */}
-      <Separator orientation="vertical" className="h-6 lg:hidden" />
+      <Separator orientation="vertical" className="separator" />
 
-      <div className="flex flex-1 gap-x-4 self-stretch lg:gap-x-6">
+      <div className="topbar-content">
         <div className="flex items-center gap-x-4 lg:gap-x-6">
           {/* Mobile branding */}
-          <div className="flex lg:hidden items-center">
+          <div className="branding-container">
             <img
-              className="h-8 w-8"
+              className="branding-logo"
               src={`${branding?.logo}?timstamp=${new Date().getTime()}`}
               alt={branding?.name}
             />
-            <span className="ml-3 text-lg font-semibold">{branding?.name}</span>
+            <span className="branding-name">{branding?.name}</span>
           </div>
         </div>
       </div>

--- a/frontend/src/components/pages/Dashboard.jsx
+++ b/frontend/src/components/pages/Dashboard.jsx
@@ -16,7 +16,7 @@ const Dashboard = ({ components, error, handleComponentUpdate }) => {
   const renderContent = () => {
     if (error) {
       return (
-        <Alert variant="destructive" className="mb-4">
+        <Alert variant="destructive" className="dashboard-error">
           <AlertDescription>{error}</AlertDescription>
         </Alert>
       );
@@ -24,10 +24,10 @@ const Dashboard = ({ components, error, handleComponentUpdate }) => {
 
     if (!isValidComponents) {
       return (
-        <div className="flex items-center justify-center h-64">
-          <div className="text-center space-y-4">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto"></div>
-            <p className="text-sm text-muted-foreground">
+        <div className="dashboard-loading-container">
+          <div className="dashboard-loading-content">
+            <div className="dashboard-loading-spinner"></div>
+            <p className="dashboard-loading-text">
               {!components ? 'Loading components...' : 'Invalid components data'}
             </p>
           </div>
@@ -37,8 +37,8 @@ const Dashboard = ({ components, error, handleComponentUpdate }) => {
 
     if (components.rows.length === 0) {
       return (
-        <div className="flex items-center justify-center h-64">
-          <p className="text-sm text-muted-foreground">No components to display</p>
+        <div className="dashboard-empty">
+          <p className="dashboard-empty-text">No components to display</p>
         </div>
       );
     }
@@ -46,7 +46,7 @@ const Dashboard = ({ components, error, handleComponentUpdate }) => {
     return <DynamicComponents components={components} onComponentUpdate={handleComponentUpdate} />;
   };
 
-  return <div className="min-h-screen">{renderContent()}</div>;
+  return <div className="dashboard-container">{renderContent()}</div>;
 };
 
 export default Dashboard;

--- a/frontend/src/components/widgets/AlertWidget.jsx
+++ b/frontend/src/components/widgets/AlertWidget.jsx
@@ -34,11 +34,8 @@ const AlertWidget = ({ message, level = 'info', className }) => {
   const Icon = config.icon;
 
   return (
-    <Alert
-      variant={config.variant}
-      className={cn('relative flex gap-x-4 items-center p-4', className)}
-    >
-      <Icon className="h-4 w-4" />
+    <Alert variant={config.variant} className={cn('alertwidget-container', className)}>
+      <Icon className="alertwidget-icon" />
       <AlertTitle>{config.title}</AlertTitle>
       <AlertDescription>{message}</AlertDescription>
     </Alert>

--- a/frontend/src/components/widgets/ButtonWidget.jsx
+++ b/frontend/src/components/widgets/ButtonWidget.jsx
@@ -19,13 +19,13 @@ const ButtonWidget = ({
       variant={variant}
       size={size}
       onClick={onClick || (() => alert('Button clicked!'))}
-      className={cn('w-full sm:w-auto px-2 py-1', loading && 'cursor-not-allowed', className)}
+      className={cn('button-container', loading && 'button-disabled', className)}
       disabled={disabled || loading}
       {...props}
     >
       {loading ? (
-        <div className="flex items-center justify-center gap-2">
-          <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+        <div className="button-loading">
+          <div className="button-spinner" />
           <span>{label}</span>
         </div>
       ) : (

--- a/frontend/src/components/widgets/CheckboxWidget.jsx
+++ b/frontend/src/components/widgets/CheckboxWidget.jsx
@@ -37,21 +37,18 @@ const CheckboxWidget = ({
   };
 
   return (
-    <div className={cn('flex items-start space-x-3 space-y-0', className)}>
+    <div className={cn('checkbox-container', className)}>
       <Checkbox
         id={id}
         checked={checked}
         onCheckedChange={handleCheckedChange}
         disabled={disabled}
       />
-      <div className="space-y-1 leading-none">
-        <Label
-          htmlFor={id}
-          className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-        >
+      <div className="checkbox-label-container">
+        <Label htmlFor={id} className="checkbox-label">
           {label}
         </Label>
-        {description && <p className="text-sm text-muted-foreground">{description}</p>}
+        {description && <p className="checkbox-description">{description}</p>}
       </div>
     </div>
   );

--- a/frontend/src/components/widgets/ConnectionInterfaceWidget.jsx
+++ b/frontend/src/components/widgets/ConnectionInterfaceWidget.jsx
@@ -34,12 +34,12 @@ const ConnectionInterfaceWidget = ({ className, onConnect, disabled = false }) =
   };
 
   return (
-    <Card className={cn('w-full', className)}>
+    <Card className={cn('connectioninterface-card', className)}>
       <CardHeader>
         <CardTitle>Connection Interface</CardTitle>
       </CardHeader>
-      <CardContent className="space-y-4">
-        <div className="space-y-2">
+      <CardContent className="connectioninterface-card-content">
+        <div className="connectioninterface-input-group">
           <Label htmlFor="source">Data Source</Label>
           <Input
             id="source"
@@ -50,7 +50,7 @@ const ConnectionInterfaceWidget = ({ className, onConnect, disabled = false }) =
           />
         </div>
 
-        <div className="space-y-2">
+        <div className="connectioninterface-input-group">
           <Label htmlFor="type">Connection Type</Label>
           <Select value={type} onValueChange={setType} disabled={disabled}>
             <SelectTrigger id="type">
@@ -66,7 +66,7 @@ const ConnectionInterfaceWidget = ({ className, onConnect, disabled = false }) =
           </Select>
         </div>
 
-        <Button className="w-full" onClick={handleConnect} disabled={!source.trim() || disabled}>
+        <Button className="connectioninterface-button" onClick={handleConnect} disabled={!source.trim() || disabled}>
           Connect
         </Button>
       </CardContent>

--- a/frontend/src/components/widgets/DAGVisualizationWidget.jsx
+++ b/frontend/src/components/widgets/DAGVisualizationWidget.jsx
@@ -147,66 +147,56 @@ const DAGVisualizationWidget = ({ id, data: rawData, content, error }) => {
 
   if (error) {
     return (
-      <Card className="border-red-200 bg-red-50">
+      <Card className="dag-visualizer-error-card">
         <CardHeader>
-          <CardTitle className="text-red-700">Error Loading DAG</CardTitle>
+          <CardTitle className="dag-visualizer-error-title">Error Loading DAG</CardTitle>
         </CardHeader>
         <CardContent>
-          <p className="text-red-600">{error}</p>
+          <p className="dag-visualizer-error-text">{error}</p>
         </CardContent>
       </Card>
     );
   }
 
   return (
-    <Card
-      className={cn(
-        'relative transition-all duration-300',
-        isFullscreen ? 'fixed inset-0 z-50 m-4' : ''
-      )}
-      ref={setRefs}
-    >
+    <Card className={cn('dag-visualizer-container', isFullscreen && 'dag-visualizer-fullscreen')} ref={setRefs}>
       {/* Header Controls */}
-      <div className="absolute top-2 right-2 z-10 flex items-center gap-2">
+      <div className="dag-visualizer-controls">
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>
               <Button variant="ghost" size="icon" onClick={() => setShowMiniMap((prev) => !prev)}>
-                <FiInfo className="h-4 w-4" />
+                <FiInfo className="dag-visualizer-tooltip-trigger" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>Toggle MiniMap</TooltipContent>
+            <TooltipContent className="dag-visualizer-tooltip-content">Toggle MiniMap</TooltipContent>
           </Tooltip>
 
           <Tooltip>
             <TooltipTrigger asChild>
               <Button variant="ghost" size="icon" onClick={toggleLock}>
-                {isLocked ? <FiLock className="h-4 w-4" /> : <FiUnlock className="h-4 w-4" />}
+                {isLocked ? <FiLock className="dag-visualizer-tooltip-trigger" /> : <FiUnlock className="dag-visualizer-tooltip-trigger" />}
               </Button>
             </TooltipTrigger>
-            <TooltipContent>{isLocked ? 'Unlock Nodes' : 'Lock Nodes'}</TooltipContent>
+            <TooltipContent className="dag-visualizer-tooltip-content">{isLocked ? 'Unlock Nodes' : 'Lock Nodes'}</TooltipContent>
           </Tooltip>
 
           <Tooltip>
             <TooltipTrigger asChild>
               <Button variant="ghost" size="icon" onClick={toggleFullscreen}>
-                {isFullscreen ? (
-                  <FiMinimize2 className="h-4 w-4" />
-                ) : (
-                  <FiMaximize2 className="h-4 w-4" />
-                )}
+                {isFullscreen ? <FiMinimize2 className="dag-visualizer-tooltip-trigger" /> : <FiMaximize2 className="dag-visualizer-tooltip-trigger" />}
               </Button>
             </TooltipTrigger>
-            <TooltipContent>{isFullscreen ? 'Exit Fullscreen' : 'Enter Fullscreen'}</TooltipContent>
+            <TooltipContent className="dag-visualizer-tooltip-content">{isFullscreen ? 'Exit Fullscreen' : 'Enter Fullscreen'}</TooltipContent>
           </Tooltip>
         </TooltipProvider>
       </div>
 
       {/* Main Content */}
-      <CardContent className={cn('p-0', isFullscreen ? 'h-full' : 'h-[600px]')}>
+      <CardContent className={cn('dag-visualizer-content', isFullscreen ? 'dag-visualizer-content-fullscreen' : 'dag-visualizer-content-default')}>
         {isLoading ? (
-          <div className="flex items-center justify-center h-full">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900"></div>
+          <div className="dag-visualizer-loading">
+            <div className="dag-visualizer-spinner"></div>
           </div>
         ) : (
           <ReactFlow
@@ -233,47 +223,40 @@ const DAGVisualizationWidget = ({ id, data: rawData, content, error }) => {
 
       {/* Node Details Panel */}
       {selectedNode && (
-        <Card
-          className={cn(
-            'absolute bottom-4 left-4 right-4 max-w-md mx-auto transition-all duration-300',
-            selectedNode ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
-          )}
-        >
-          <CardHeader className="pb-2">
+        <Card className={cn('dag-visualizer-node-panel', selectedNode ? 'dag-visualizer-node-panel-visible' : 'dag-visualizer-node-panel-hidden')}>
+          <CardHeader className="dag-visualizer-node-header">
             <div className="flex justify-between items-center">
-              <CardTitle className="text-lg">{selectedNode.label}</CardTitle>
+              <CardTitle className="dag-visualizer-node-title">{selectedNode.label}</CardTitle>
               <Button variant="ghost" size="icon" onClick={() => setSelectedNode(null)}>
-                <span className="sr-only">Close</span>×
+                <span className="dag-visualizer-node-close">Close</span>×
               </Button>
             </div>
           </CardHeader>
-          <CardContent className="space-y-3">
-            <div className="flex items-center gap-2">
-              <span className="text-sm font-medium text-muted-foreground">Status:</span>
+          <CardContent className="dag-visualizer-node-details">
+            <div className="dag-visualizer-node-status">
+              <span className="dag-visualizer-node-status-label">Status:</span>
               <Badge variant="secondary" className={getStatusColor(selectedNode.status)}>
                 {selectedNode.status}
               </Badge>
             </div>
             <div>
-              <span className="text-sm font-medium text-muted-foreground">Execution Time:</span>
+              <span className="dag-visualizer-node-status-label">Execution Time:</span>
               <span className="ml-2 text-sm">{selectedNode.executionTime}</span>
             </div>
             <div>
-              <span className="text-sm font-medium text-muted-foreground">Attempts:</span>
+              <span className="dag-visualizer-node-status-label">Attempts:</span>
               <span className="ml-2 text-sm">{selectedNode.attempts}</span>
             </div>
             {selectedNode.error && (
               <div>
-                <span className="text-sm font-medium text-red-500">Error:</span>
-                <p className="mt-1 text-sm text-red-600 bg-red-50 p-2 rounded">
-                  {selectedNode.error}
-                </p>
+                <span className="dag-visualizer-node-error-label">Error:</span>
+                <p className="dag-visualizer-node-error-text">{selectedNode.error}</p>
               </div>
             )}
             {selectedNode.dependencies?.length > 0 && (
               <div>
-                <span className="text-sm font-medium text-muted-foreground">Dependencies:</span>
-                <div className="mt-1 flex flex-wrap gap-1">
+                <span className="dag-visualizer-node-status-label">Dependencies:</span>
+                <div className="dag-visualizer-node-dependencies">
                   {selectedNode.dependencies.map((dep) => (
                     <Badge key={dep} variant="outline" className="text-xs">
                       {dep}

--- a/frontend/src/components/widgets/DataVisualizationWidget.jsx
+++ b/frontend/src/components/widgets/DataVisualizationWidget.jsx
@@ -167,18 +167,18 @@ const DataVisualizationWidget = ({ id, data: rawData, content, error, className 
   }
 
   return (
-    <Card className={cn('w-full h-full', className)} ref={setRefs}>
-      <CardContent className="p-0">
+    <Card className={cn('plotly-container', className)} ref={setRefs}>
+      <CardContent className="plotly-card-content">
         {!inView || isLoading ? (
-          <div className="flex flex-col items-center justify-center h-64">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mb-4"></div>
-            <p className="text-sm text-muted-foreground">Loading visualization...</p>
+          <div className="plotly-loading-container">
+            <div className="plotly-loading-spinner"></div>
+            <p className="plotly-loading-text">Loading visualization...</p>
           </div>
         ) : processedData?.data ? (
-          <div className="relative w-full" style={{ minHeight: '400px' }}>
+          <div className="plotly-plot-container">
             {loadedDataPercentage > 0 && loadedDataPercentage < 100 && (
-              <div className="absolute top-0 left-0 right-0 z-10 bg-background/80 backdrop-blur-sm px-4 py-2">
-                <Progress value={loadedDataPercentage} className="w-full h-2" />
+              <div className="plotly-progress-container">
+                <Progress value={loadedDataPercentage} className="plotly-progress-bar" />
               </div>
             )}
             <Plot
@@ -208,7 +208,7 @@ const DataVisualizationWidget = ({ id, data: rawData, content, error, className 
                 showAxisRangeEntryBoxes: false,
                 ...processedData.config,
               }}
-              className="w-full h-full"
+              className="plotly-plot"
               useResizeHandler={true}
               style={{ width: '100%', height: '100%' }}
               onError={(err) => {
@@ -218,7 +218,7 @@ const DataVisualizationWidget = ({ id, data: rawData, content, error, className 
             />
           </div>
         ) : (
-          <div className="w-full h-full" ref={plotContainerRef} />
+          <div className="plotly-plot" ref={plotContainerRef} />
         )}
       </CardContent>
     </Card>

--- a/frontend/src/components/widgets/ImageWidget.jsx
+++ b/frontend/src/components/widgets/ImageWidget.jsx
@@ -17,22 +17,22 @@ const ImageWidget = ({
 }) => {
   // Define size classes based on the provided size prop
   const sizeClasses = {
-    small: 'w-24',
-    medium: 'w-48',
-    large: 'w-96',
-    full: 'w-full',
+    small: 'image-widget-small',
+    medium: 'image-widget-medium',
+    large: 'image-widget-large',
+    full: 'image-widget-full',
   };
 
   const ImageComponent = (
     <div className={cn(sizeClasses[size], className)}>
-      <AspectRatio ratio={aspectRatio} className="overflow-hidden">
+      <AspectRatio ratio={aspectRatio} className="image-widget-container">
         <img
           src={src}
           alt={alt}
           className={cn(
-            'h-full w-full object-cover transition-transform duration-200 hover:scale-105',
-            rounded && 'rounded-lg',
-            objectFit === 'contain' && 'object-contain'
+            'image-widget-img',
+            rounded && 'image-widget-rounded',
+            objectFit === 'contain' && 'image-widget-object-contain'
           )}
         />
       </AspectRatio>
@@ -41,7 +41,7 @@ const ImageWidget = ({
 
   if (withCard) {
     return (
-      <Card className={cn('p-2', rounded && 'rounded-lg', sizeClasses[size], className)}>
+      <Card className={cn('image-widget-card', rounded && 'image-widget-rounded', sizeClasses[size], className)}>
         {ImageComponent}
       </Card>
     );

--- a/frontend/src/components/widgets/MarkdownRendererWidget.jsx
+++ b/frontend/src/components/widgets/MarkdownRendererWidget.jsx
@@ -28,54 +28,17 @@ const MarkdownRendererWidget = ({
   }
 
   const variantStyles = {
-    default: 'bg-card',
-    outline: 'border rounded-lg',
-    ghost: 'bg-transparent',
+    default: 'markdown-card-variant-default',
+    outline: 'markdown-card-variant-outline',
+    ghost: 'markdown-card-variant-ghost',
   };
 
   const components = {
-    // Style headings
-    h1: ({ className, ...props }) => (
-      <h1
-        className={cn('scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl', className)}
-        {...props}
-      />
-    ),
-    h2: ({ className, ...props }) => (
-      <h2
-        className={cn(
-          'scroll-m-20 pb-2 text-3xl font-semibold tracking-tight first:mt-0',
-          className
-        )}
-        {...props}
-      />
-    ),
-    h3: ({ className, ...props }) => (
-      <h3
-        className={cn('scroll-m-20 text-2xl font-semibold tracking-tight', className)}
-        {...props}
-      />
-    ),
-    // Style links
-    a: ({ className, ...props }) => (
-      <a
-        className={cn('font-medium text-primary underline underline-offset-4', className)}
-        {...props}
-      />
-    ),
-    // Style code blocks
-    pre: ({ className, ...props }) => (
-      <pre
-        className={cn(
-          'mb-6 mt-6 overflow-x-auto rounded-lg',
-          'bg-zinc-950 dark:bg-zinc-900',
-          'border border-zinc-200 dark:border-zinc-800',
-          'p-4 shadow-sm',
-          className
-        )}
-        {...props}
-      />
-    ),
+    h1: ({ className, ...props }) => <h1 className={cn('markdown-heading-1', className)} {...props} />,
+    h2: ({ className, ...props }) => <h2 className={cn('markdown-heading-2', className)} {...props} />,
+    h3: ({ className, ...props }) => <h3 className={cn('markdown-heading-3', className)} {...props} />,
+    a: ({ className, ...props }) => <a className={cn('markdown-link', className)} {...props} />,
+    pre: ({ className, ...props }) => <pre className={cn('markdown-pre-wrapper', className)} {...props} />,
     code: ({ node, inline, className, children, ...props }) => {
       const match = /language-(\w+)/.exec(className || '');
       const lang = match ? match[1] : '';
@@ -83,17 +46,7 @@ const MarkdownRendererWidget = ({
 
       if (isInline) {
         return (
-          <code
-            className={cn(
-              'relative rounded px-[0.3rem] py-[0.2rem] font-mono text-sm',
-              'bg-zinc-100 dark:bg-zinc-800',
-              'text-zinc-900 dark:text-zinc-100',
-              'whitespace-normal',
-              'inline-block',
-              className
-            )}
-            {...props}
-          >
+          <code className={cn('markdown-inline-code', className)} {...props}>
             {children}
           </code>
         );
@@ -101,84 +54,35 @@ const MarkdownRendererWidget = ({
 
       return (
         <div className="relative">
-          {lang && (
-            <div className="absolute right-2 top-2 z-10">
-              <span className="rounded-md bg-zinc-700 px-2 py-1 text-xs font-medium text-zinc-200">
-                {lang}
-              </span>
-            </div>
-          )}
+          {lang && <div className="markdown-code-lang">{lang}</div>}
           <SyntaxHighlighter
             language={lang}
             style={oneDark}
-            customStyle={{
-              margin: 0,
-              borderRadius: '0.5rem',
-              background: 'rgb(24 24 27)',
-            }}
+            customStyle={{ margin: 0, borderRadius: '0.5rem', background: 'rgb(24 24 27)' }}
           >
             {String(children).replace(/\n$/, '')}
           </SyntaxHighlighter>
         </div>
       );
     },
-    // Style blockquotes
-    blockquote: ({ className, ...props }) => (
-      <blockquote className={cn('mt-6 border-l-2 pl-6 italic', className)} {...props} />
-    ),
-    // Style lists
-    ul: ({ className, ...props }) => (
-      <ul className={cn('my-6 ml-6 list-disc [&>li]:mt-2', className)} {...props} />
-    ),
-    ol: ({ className, ...props }) => (
-      <ol className={cn('my-6 ml-6 list-decimal [&>li]:mt-2', className)} {...props} />
-    ),
-    // Style tables
+    blockquote: ({ className, ...props }) => <blockquote className={cn('markdown-blockquote', className)} {...props} />,
+    ul: ({ className, ...props }) => <ul className={cn('markdown-ul', className)} {...props} />,
+    ol: ({ className, ...props }) => <ol className={cn('markdown-ol', className)} {...props} />,
     table: ({ className, ...props }) => (
-      <div className="my-6 w-full overflow-y-auto">
-        <table className={cn('w-full', className)} {...props} />
+      <div className="markdown-table-wrapper">
+        <table className={cn('markdown-table', className)} {...props} />
       </div>
     ),
-    th: ({ className, ...props }) => (
-      <th
-        className={cn(
-          'border px-4 py-2 text-left font-bold [&[align=center]]:text-center [&[align=right]]:text-right',
-          className
-        )}
-        {...props}
-      />
-    ),
-    td: ({ className, ...props }) => (
-      <td
-        className={cn(
-          'border px-4 py-2 text-left [&[align=center]]:text-center [&[align=right]]:text-right',
-          className
-        )}
-        {...props}
-      />
-    ),
+    th: ({ className, ...props }) => <th className={cn('markdown-th', className)} {...props} />,
+    td: ({ className, ...props }) => <td className={cn('markdown-td', className)} {...props} />,
   };
 
   return (
-    <Card
-      className={cn(
-        'w-full',
-        variantStyles[variant],
-        variant === 'ghost' && 'border-none shadow-none',
-        className
-      )}
-    >
+    <Card className={cn('markdown-container', variantStyles[variant], className)}>
       <CardContent
         className={cn(
-          'prose prose-sm md:prose-base lg:prose-lg dark:prose-invert max-w-none',
-          'prose-headings:scroll-m-20',
-          'prose-p:leading-7',
-          'prose-li:marker:text-muted-foreground',
-          'prose-pre:p-0',
-          'prose-pre:bg-transparent',
-          'prose-code:text-zinc-900 dark:prose-code:text-zinc-100',
-          'prose-pre:shadow-lg',
-          variant === 'ghost' ? 'p-0' : 'p-6'
+          'markdown-card-content markdown-headings markdown-paragraph markdown-list markdown-pre markdown-code',
+          variant === 'ghost' ? 'p-0' : 'markdown-padding'
         )}
       >
         <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>

--- a/frontend/src/components/widgets/ProgressWidget.jsx
+++ b/frontend/src/components/widgets/ProgressWidget.jsx
@@ -18,41 +18,34 @@ const ProgressWidget = ({
 
   // Size variants for the progress bar
   const sizeVariants = {
-    sm: 'h-2',
-    default: 'h-3',
-    lg: 'h-4',
+    sm: 'progress-size-sm',
+    default: 'progress-size-default',
+    lg: 'progress-size-lg',
   };
 
   return (
-    <Card className={cn('w-full', className)}>
-      <CardHeader className="pb-2">
-        <div className="flex items-center justify-between">
-          <CardTitle className="text-sm font-medium text-muted-foreground">{label}</CardTitle>
-          {showValue && (
-            <span className="text-sm font-medium text-muted-foreground">
-              {Math.round(normalizedValue)}%
-            </span>
-          )}
+    <Card className={cn('progress-container', className)}>
+      <CardHeader className="progress-header">
+        <div className="progress-header-content">
+          <CardTitle className="progress-label">{label}</CardTitle>
+          {showValue && <span className="progress-value">{Math.round(normalizedValue)}%</span>}
         </div>
       </CardHeader>
       <CardContent>
         {/* Progress bar */}
-        <Progress
-          value={normalizedValue}
-          className={cn(sizeVariants[size], 'transition-all duration-300')}
-        />
+        <Progress value={normalizedValue} className={cn('progress-bar', sizeVariants[size])} />
 
         {/* Steps */}
         {steps && steps.length > 0 && (
-          <div className="mt-4 grid grid-cols-4 gap-2">
+          <div className="progress-steps">
             {steps.map((step, index) => {
               const isActive = index < steps.length * (normalizedValue / 100);
               return (
                 <div
                   key={index}
                   className={cn(
-                    'text-center text-sm transition-colors duration-200',
-                    isActive ? 'text-primary font-medium' : 'text-muted-foreground'
+                    'progress-step',
+                    isActive ? 'progress-step-active' : 'progress-step-inactive'
                   )}
                 >
                   {step}

--- a/frontend/src/components/widgets/SelectboxWidget.jsx
+++ b/frontend/src/components/widgets/SelectboxWidget.jsx
@@ -50,42 +50,42 @@ const SelectboxWidget = ({
 
   // Size variants
   const sizeVariants = {
-    sm: 'h-8 text-xs',
-    default: 'h-10 text-sm',
-    lg: 'h-12 text-base',
+    sm: 'selectbox-size-sm',
+    default: 'selectbox-size-default',
+    lg: 'selectbox-size-lg',
   };
 
   return (
-    <div className={cn('space-y-2', className)}>
+    <div className={cn('selectbox-container', className)}>
       {label && (
         <Label
           htmlFor={id}
           className={cn(
-            'text-sm font-medium',
-            error && 'text-destructive',
-            disabled && 'opacity-50'
+            'selectbox-label',
+            error && 'selectbox-label-error',
+            disabled && 'selectbox-label-disabled'
           )}
         >
           {label}
-          {required && <span className="text-destructive ml-1">*</span>}
+          {required && <span className="selectbox-required">*</span>}
         </Label>
       )}
       <Select value={value} onValueChange={handleValueChange} disabled={disabled}>
         <SelectTrigger
           id={id}
-          className={cn(sizeVariants[size], error && 'border-destructive focus:ring-destructive')}
+          className={cn('selectbox-trigger', sizeVariants[size], error && 'selectbox-error')}
         >
           <SelectValue placeholder={placeholder} />
         </SelectTrigger>
-        <SelectContent className="min-w-[var(--radix-select-trigger-width)]">
+        <SelectContent className="selectbox-content">
           {options.map((option, index) => (
             <SelectItem
               key={index}
               value={option}
               className={cn(
-                'cursor-pointer w-full data-[highlighted]:bg-muted data-[highlighted]:text-foreground px-4',
-                size === 'sm' && 'text-xs py-1.5',
-                size === 'lg' && 'text-base py-2.5'
+                'selectbox-option',
+                size === 'sm' && 'selectbox-option-sm',
+                size === 'lg' && 'selectbox-option-lg'
               )}
             >
               {option}
@@ -93,7 +93,7 @@ const SelectboxWidget = ({
           ))}
         </SelectContent>
       </Select>
-      {error && <p className="text-xs text-destructive mt-1">{error}</p>}
+      {error && <p className="selectbox-error-message">{error}</p>}
     </div>
   );
 };

--- a/frontend/src/components/widgets/SliderWidget.jsx
+++ b/frontend/src/components/widgets/SliderWidget.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 
 import { Card, CardContent } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
-import { Slider } from '@/components/ui/slider';
-
 import { cn } from '@/lib/utils';
 
 const SliderWidget = ({
@@ -43,26 +41,17 @@ const SliderWidget = ({
   }, [value]);
 
   const SliderContent = (
-    <div className={cn('space-y-4', className)}>
-      <div className="flex items-center justify-between">
-        <Label htmlFor={id} className={cn('text-sm font-medium', disabled && 'opacity-50')}>
+    <div className={cn('slider-container', className)}>
+      <div className="slider-header">
+        <Label
+          htmlFor={id}
+          className={cn('slider-label', disabled && 'slider-label-disabled')}
+        >
           {label}
         </Label>
-        {showValue && (
-          <span className="text-sm text-muted-foreground font-medium">{localValue}</span>
-        )}
+        {showValue && <span className="slider-value">{localValue}</span>}
       </div>
-      {/* <Slider
-        id={id}
-        min={min}
-        max={max}
-        step={step}
-        value={[localValue]}
-        onValueChange={handleValueChange}
-        disabled={disabled}
-        className="w-full text-black"
-      /> */}
-      <div className="p-4 bg-white">
+      <div className="slider-wrapper">
         <div className="mt-2">
           <input
             id={id}
@@ -75,14 +64,14 @@ const SliderWidget = ({
             onChange={handleChange}
             onMouseUp={handleMouseUp}
             onTouchEnd={handleMouseUp}
-            className="w-full h-2 bg-gray-200 rounded-lg appearance-none focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            className="slider-track"
           />
         </div>
       </div>
       {showMinMax && (
-        <div className="flex justify-between">
-          <span className="text-sm text-muted-foreground">{min}</span>
-          <span className="text-sm text-muted-foreground">{max}</span>
+        <div className="slider-min-max">
+          <span className="slider-minmax-label">{min}</span>
+          <span className="slider-minmax-label">{max}</span>
         </div>
       )}
     </div>
@@ -91,7 +80,7 @@ const SliderWidget = ({
   if (variant === 'card') {
     return (
       <Card>
-        <CardContent className="pt-6">{SliderContent}</CardContent>
+        <CardContent className="slider-card-content">{SliderContent}</CardContent>
       </Card>
     );
   }

--- a/frontend/src/components/widgets/SpinnerWidget.jsx
+++ b/frontend/src/components/widgets/SpinnerWidget.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
-
 import { Card, CardContent } from '@/components/ui/card';
-
 import { cn } from '@/lib/utils';
 
 const SpinnerWidget = ({
@@ -13,28 +11,22 @@ const SpinnerWidget = ({
 }) => {
   // Size variants for the spinner
   const sizeVariants = {
-    sm: 'w-4 h-4 border-2',
-    default: 'w-8 h-8 border-3',
-    lg: 'w-12 h-12 border-4',
+    sm: 'spinner-size-sm',
+    default: 'spinner-size-default',
+    lg: 'spinner-size-lg',
   };
 
   const SpinnerContent = (
-    <div className={cn('flex flex-col items-center justify-center gap-3 p-4', className)}>
-      {showLabel && label && <p className="text-sm font-medium text-muted-foreground">{label}</p>}
-      <div
-        className={cn(
-          'rounded-full animate-spin',
-          'border-primary/30 border-t-primary',
-          sizeVariants[size]
-        )}
-      />
+    <div className={cn('spinner-container', className)}>
+      {showLabel && label && <p className="spinner-label">{label}</p>}
+      <div className={cn('spinner-animation', sizeVariants[size])} />
     </div>
   );
 
   if (variant === 'card') {
     return (
       <Card>
-        <CardContent className="pt-6">{SpinnerContent}</CardContent>
+        <CardContent className="spinner-card-content">{SpinnerContent}</CardContent>
       </Card>
     );
   }

--- a/frontend/src/components/widgets/TableViewerWidget.jsx
+++ b/frontend/src/components/widgets/TableViewerWidget.jsx
@@ -29,43 +29,43 @@ const TableViewerWidget = ({
 
   if (!data || data.length === 0) {
     return (
-      <Card className={cn('w-full', className)}>
-        <CardContent className="flex items-center justify-center py-6">
-          <p className="text-sm text-muted-foreground">No data available</p>
+      <Card className={cn('tableviewer-card', className)}>
+        <CardContent className="tableviewer-card-content">
+          <p className="tableviewer-no-data-text">No data available</p>
         </CardContent>
       </Card>
     );
   }
 
   const TableContent = (
-    <div className={cn('w-full', className)}>
-      <div className="flex items-center justify-between mb-2">
-        {showTitle && <h3 className="text-lg font-medium">{title}</h3>}
+    <div className={cn('tableviewer-container', className)}>
+      <div className="tableviewer-header">
+        {showTitle && <h3 className="tableviewer-title">{title}</h3>}
         <Button
           variant="ghost"
           size="sm"
-          className="p-0 h-9 w-9 flex items-center justify-center"
+          className="tableviewer-toggle-button"
           onClick={() => setIsExpanded(!isExpanded)}
         >
           <ChevronDown
             className={cn(
-              'h-4 w-4 transition-transform duration-200 m-auto',
-              isExpanded ? '' : '-rotate-90'
+              'tableviewer-chevron',
+              !isExpanded && 'tableviewer-chevron-rotated'
             )}
           />
         </Button>
       </div>
       <div
         className={cn(
-          'overflow-auto transition-all duration-200 ease-in-out',
-          isExpanded ? 'opacity-100 max-h-[2000px]' : 'opacity-0 max-h-0'
+          'tableviewer-table-container',
+          isExpanded ? 'tableviewer-expanded' : 'tableviewer-collapsed'
         )}
       >
         <Table>
           <TableHeader>
             <TableRow>
               {Object.keys(data[0]).map((key) => (
-                <TableHead key={key} className="font-medium">
+                <TableHead key={key} className="tableviewer-header-cell">
                   {key}
                 </TableHead>
               ))}
@@ -76,13 +76,14 @@ const TableViewerWidget = ({
               <TableRow
                 key={index}
                 className={cn(
-                  hoverable && 'cursor-pointer hover:bg-muted/50',
-                  striped && index % 2 === 0 && 'bg-muted/50',
-                  dense ? 'h-8' : 'h-12'
+                  'tableviewer-row',
+                  hoverable && 'tableviewer-hoverable',
+                  striped && index % 2 === 0 && 'tableviewer-striped',
+                  dense ? 'tableviewer-dense' : 'tableviewer-normal'
                 )}
               >
                 {Object.values(row).map((value, idx) => (
-                  <TableCell key={idx} className={cn('p-2 md:p-4', dense && 'py-1 text-sm')}>
+                  <TableCell key={idx} className={cn('tableviewer-cell', dense && 'tableviewer-cell-dense')}>
                     {value !== null && value !== undefined ? value : 'N/A'}
                   </TableCell>
                 ))}
@@ -96,20 +97,20 @@ const TableViewerWidget = ({
 
   if (variant === 'card') {
     return (
-      <Card className={cn('w-full', className)}>
+      <Card className={cn('tableviewer-card', className)}>
         {showTitle && (
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardHeader className="tableviewer-card-header">
             <CardTitle>{title}</CardTitle>
             <Button
               variant="ghost"
               size="sm"
-              className="p-0 h-9 w-9 flex items-center justify-center"
+              className="tableviewer-toggle-button"
               onClick={() => setIsExpanded(!isExpanded)}
             >
               <ChevronDown
                 className={cn(
-                  'h-4 w-4 transition-transform duration-200 m-auto',
-                  isExpanded ? '' : '-rotate-90'
+                  'tableviewer-chevron',
+                  !isExpanded && 'tableviewer-chevron-rotated'
                 )}
               />
             </Button>
@@ -117,8 +118,9 @@ const TableViewerWidget = ({
         )}
         <CardContent
           className={cn(
-            'transition-all duration-200 ease-in-out p-0',
-            isExpanded ? 'opacity-100' : 'opacity-0 h-0 overflow-hidden'
+            isExpanded
+              ? 'tableviewer-card-content-expanded'
+              : 'tableviewer-card-content-collapsed'
           )}
         >
           {TableContent}

--- a/frontend/src/components/widgets/TextInputWidget.jsx
+++ b/frontend/src/components/widgets/TextInputWidget.jsx
@@ -44,24 +44,24 @@ const TextInputWidget = ({
 
   // Size variants
   const sizeVariants = {
-    sm: 'h-8 text-xs',
-    default: 'h-10 text-sm',
-    lg: 'h-12 text-base',
+    sm: 'inputfield-size-sm',
+    default: 'inputfield-size-default',
+    lg: 'inputfield-size-lg',
   };
 
   return (
-    <div className={cn('space-y-2', className)}>
+    <div className={cn('inputfield-container', className)}>
       {label && (
         <Label
           htmlFor={id}
           className={cn(
-            'text-sm font-medium',
-            error && 'text-destructive',
-            disabled && 'opacity-50'
+            'inputfield-label',
+            error && 'inputfield-error',
+            disabled && 'inputfield-disabled'
           )}
         >
           {label}
-          {required && <span className="text-destructive ml-1">*</span>}
+          {required && <span className="inputfield-required">*</span>}
         </Label>
       )}
       <Input
@@ -74,13 +74,13 @@ const TextInputWidget = ({
         disabled={disabled}
         className={cn(
           sizeVariants[size],
-          variant === 'ghost' && 'border-none shadow-none',
-          error && 'border-destructive focus-visible:ring-destructive'
+          variant === 'ghost' && 'inputfield-variant-ghost',
+          error && 'inputfield-error-border'
         )}
         aria-invalid={error ? 'true' : undefined}
         required={required}
       />
-      {error && <p className="text-xs text-destructive mt-1">{error}</p>}
+      {error && <p className="inputfield-error-message">{error}</p>}
     </div>
   );
 };

--- a/frontend/src/components/widgets/UnknownWidget.jsx
+++ b/frontend/src/components/widgets/UnknownWidget.jsx
@@ -15,22 +15,22 @@ const UnknownWidget = ({
   return (
     <Alert
       variant={variant === 'default' ? 'default' : 'destructive'}
-      className={cn('border-2', className)}
+      className={cn('unknownwidget-container', className)}
     >
-      <ExclamationTriangleIcon className="h-4 w-4" />
+      <ExclamationTriangleIcon className="unknownwidget-icon" />
       <AlertTitle>Unknown Widget Type</AlertTitle>
-      <AlertDescription className="mt-2">
-        <div className="space-y-2 text-sm">
+      <AlertDescription className="unknownwidget-description">
+        <div className="unknownwidget-text">
           <p>
-            The widget type <code className="font-mono bg-muted px-1 py-0.5 rounded">{type}</code>{' '}
+            The widget type <code className="unknownwidget-code">{type}</code>{' '}
             is not recognized.
           </p>
           {id && (
-            <p className="text-muted-foreground">
+            <p className="unknownwidget-muted-text">
               Widget ID: <code className="font-mono">{id}</code>
             </p>
           )}
-          <p className="text-muted-foreground">
+          <p className="unknownwidget-muted-text">
             Please check the widget type and ensure it is correctly specified.
           </p>
         </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 :root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 
 import App from './App';
+import './components.css';
 // Import your main App component
 import './styles.css';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,286 @@
+{
+  "name": "preswald",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@trivago/prettier-plugin-sort-imports": "^5.2.2"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.10.tgz",
+      "integrity": "sha512-rRHT8siFIXQrAYOYqZQVsAr8vJ+cBNqcVAY6m5V8/4QqzaPl+zDBe6cLEPRDuNOUf3ww8RfJVlOyQMoSI+5Ang==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.26.10",
+        "@babel/types": "^7.26.10",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.10.tgz",
+      "integrity": "sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.26.10"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
+      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "@babel/parser": "^7.26.9",
+        "@babel/types": "^7.26.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.10.tgz",
+      "integrity": "sha512-k8NuDrxr0WrPH5Aupqb2LCVURP/S0vBEn5mK6iH+GIYob66U5EtoZvcdudR2jQ4cmTwhEwW1DLB+Yyas9zjF6A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.10",
+        "@babel/parser": "^7.26.10",
+        "@babel/template": "^7.26.9",
+        "@babel/types": "^7.26.10",
+        "debug": "^4.3.1",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
+      "integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-5.2.2.tgz",
+      "integrity": "sha512-fYDQA9e6yTNmA13TLVSA+WMQRc5Bn/c0EUBditUHNfMMxN7M82c38b1kEggVE3pLpZ0FwkwJkUEKMiOi52JXFA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "^7.26.5",
+        "@babel/parser": "^7.26.7",
+        "@babel/traverse": "^7.26.7",
+        "@babel/types": "^7.26.7",
+        "javascript-natural-sort": "^0.7.1",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">18.12"
+      },
+      "peerDependencies": {
+        "@vue/compiler-sfc": "3.x",
+        "prettier": "2.x - 3.x",
+        "prettier-plugin-svelte": "3.x",
+        "svelte": "4.x || 5.x"
+      },
+      "peerDependenciesMeta": {
+        "@vue/compiler-sfc": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+      "dev": true
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "@trivago/prettier-plugin-sort-imports": "^5.2.2"
+  }
+}


### PR DESCRIPTION
This PR moves all hard-coded Tailwind styling strings into `components.css` and uses `@apply` in Tailwind for styling. This is the first step to separate styles from component definitions. A future pass will be needed to group similar styles for better consistency.  

#### Testing  
1. Built the frontend with:  
```bash
python setup.py build_frontend
```
2. Verified components work by running:  
```bash
cd preswald/tutorial
preswald run
```
3. Confirmed everything functions correctly at `localhost:8501`.  
