### PR TITLE
fix: selectbox overflow styling

### DIFF
--- a/frontend/src/components.css
+++ b/frontend/src/components.css
@@ -1,4 +1,12 @@
 /* app.css */
+.selectbox-trigger {
+  @apply min-w-[8rem];
+}
+
+.selectbox-content {
+  @apply max-h-96 min-w-[8rem];
+}
+
 .main-content-collapsed-sidebar {
   @apply lg:pl-20 transition-all duration-300;
 }

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -73,7 +73,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "relative z-50 rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className


### PR DESCRIPTION
**Related Issue**
Fixes #387 

**Description of Changes**
fixing the styling of select box so that it doesn't overflow when there are a lot of select items.

before:
<img width="1123" alt="before" src="https://github.com/user-attachments/assets/216d8483-04d0-45cc-8ea7-72f76b254c79" />


after:
<img width="1123" alt="after" src="https://github.com/user-attachments/assets/1c2786b2-52a5-455c-8657-19cc9c94e5f5" />

**Type of Change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] New example
- [ ] Test improvement

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run my code against examples and ensured no errors
- [x] Any dependent changes have been merged and published in downstream modules

