### PR TITLE
fix: improve initial loading state

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,7 @@ const App = () => {
   const [error, setError] = useState(null);
   const [config, setConfig] = useState(null);
   const [isConnected, setIsConnected] = useState(false);
+  const [areComponentsLoading, setAreComponentsLoading] = useState(true);
 
   useEffect(() => {
     comm.connect();
@@ -67,6 +68,7 @@ const App = () => {
 
   const refreshComponentsList = (components) => {
     if (!components || !components.rows) {
+      setAreComponentsLoading(false);
       console.warn('[App] Invalid components data received:', components);
       setComponents({ rows: [] });
       return;
@@ -87,10 +89,12 @@ const App = () => {
       );
 
       console.log('[App] Updating components with:', { rows: updatedRows });
+      setAreComponentsLoading(false);
       setComponents({ rows: updatedRows });
       setError(null);
     } catch (error) {
       console.error('[App] Error processing components:', error);
+      setAreComponentsLoading(false);
       setError('Error processing components data');
       setComponents({ rows: [] });
     }
@@ -156,7 +160,7 @@ const App = () => {
   return (
     <Router>
       <Layout>
-        {!isConnected ? (
+        {!isConnected || areComponentsLoading ? (
           <LoadingState />
         ) : (
           <Dashboard

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -150,7 +150,7 @@ const App = () => {
     <div className="loading-container">
       <div className="loading-content">
         <div className="loading-spinner"></div>
-        <p className="loading-text">Connecting...</p>
+        <p className="loading-text">{isConnected ? 'Loading Components...' : 'Connecting...'}</p>
       </div>
     </div>
   );

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -102,6 +102,7 @@ const App = () => {
 
   const handleError = (errorContent) => {
     console.error('[App] Received error:', errorContent);
+    setAreComponentsLoading(false);
     setError(errorContent.message);
 
     if (errorContent.componentId) {


### PR DESCRIPTION
**Related Issue**
-

**Description of Changes**
Small fix to improve the initial loading state of the app.

Previously it used to show text `No components to display` during first load after websocket connection is successful but components aren't loaded yet. Added a new state to check if components are loaded and keep showing loading indicator until then which prevents showing `No components to display` text during first load.

**Type of Change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] New example
- [ ] Test improvement

**Testing**
Before:

https://github.com/user-attachments/assets/10b02668-6f89-4d94-83eb-9643aac85099



After:



https://github.com/user-attachments/assets/3f3437d4-d9b6-4bd5-964a-34ae89ea8e4f





**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run my code against examples and ensured no errors
- [x] Any dependent changes have been merged and published in downstream modules