### PR TITLE
Added matplotlib component

### DIFF
--- a/examples/iris/hello.py
+++ b/examples/iris/hello.py
@@ -1,6 +1,9 @@
+
+import matplotlib.pyplot as plt
+import numpy as np
 import plotly.express as px
 
-from preswald import connect, get_df, plotly, sidebar, table, text
+from preswald import connect, get_df, matplotlib, plotly, sidebar, table, text
 
 
 # Report Title
@@ -81,8 +84,20 @@ fig10 = px.density_contour(
 fig10.update_layout(template="plotly_white")
 plotly(fig10)
 
+
 # Show the first 10 rows of the dataset
 text(
     "## Sample of the Iris Dataset \n Below is a preview of the first 10 rows of the dataset, showing key measurements for each iris species."
 )
 table(df, limit=10)
+
+# Create a simple sine wave plot
+x = np.linspace(0, 10, 100)
+y = np.sin(x)
+
+fig, ax = plt.subplots()
+ax.plot(x, y)
+ax.set_title("Sine Wave Test")
+
+# Render Matplotlib figure in the Preswald app
+matplotlib(fig)

--- a/frontend/src/components/DynamicComponents.jsx
+++ b/frontend/src/components/DynamicComponents.jsx
@@ -1,6 +1,7 @@
 import React, { memo } from 'react';
 
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import MatplotlibWidget from '@/components/widgets/MatplotlibWidget';
 
 import { cn } from '@/lib/utils';
 
@@ -79,6 +80,9 @@ const MemoizedComponent = memo(
             className={component.className}
           />
         );
+
+      case 'matplotlib':
+        return <MatplotlibWidget {...commonProps} image={component.image} />;
 
       case 'slider':
         return (

--- a/frontend/src/components/widgets/MatplotlibWidget.jsx
+++ b/frontend/src/components/widgets/MatplotlibWidget.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { Card } from '@/components/ui/card';
+
+import { cn } from '@/lib/utils';
+
+const MatplotlibWidget = ({ _label, image, className }) => {
+  return (
+    <Card className={cn('w-full', className)}>
+      {_label && <h3 className="text-lg font-medium mb-2">{_label}</h3>}
+      {image ? (
+        <img src={`data:image/png;base64,${image}`} alt="Matplotlib Plot" className="w-full" />
+      ) : (
+        <p>No plot available</p>
+      )}
+    </Card>
+  );
+};
+
+export default MatplotlibWidget;

--- a/preswald/interfaces/__init__.py
+++ b/preswald/interfaces/__init__.py
@@ -8,6 +8,7 @@ from .components import (
     button,
     checkbox,
     image,
+    matplotlib,
     plotly,
     progress,
     selectbox,

--- a/preswald/interfaces/components.py
+++ b/preswald/interfaces/components.py
@@ -1,9 +1,12 @@
+import base64
 import hashlib
+import io
 import json
 import logging
 import uuid
 from typing import Dict, List, Optional
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
@@ -84,6 +87,35 @@ def image(src, alt="Image", size=1.0):
     logger.debug(f"Created component: {component}")
     service.append_component(component)
     return component
+
+
+def matplotlib(fig: Optional[plt.Figure] = None, label: str = "plot") -> str:
+    """Render a Matplotlib figure as a component."""
+    service = PreswaldService.get_instance()
+
+    if fig is None:
+        fig, ax = plt.subplots()
+        ax.plot([0, 1, 2], [0, 1, 4])
+
+    # Save the figure as a base64-encoded PNG
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png")
+    buf.seek(0)
+    img_b64 = base64.b64encode(buf.read()).decode()
+
+    # Generate a unique component ID based on the label
+    component_id = f"matplotlib-{hashlib.md5(label.encode()).hexdigest()[:8]}"
+
+    component = {
+        "type": "matplotlib",
+        "id": component_id,
+        "label": label,
+        "image": img_b64,  # Store the image data
+    }
+
+    service.append_component(component)
+
+    return component_id  # Returning ID for potential tracking
 
 
 def plotly(fig, size: float = 1.0) -> Dict:  # noqa: C901


### PR DESCRIPTION
This PR adds support for visualizing data using Matplotlib. Key changes include:

- Backend integration to generate Matplotlib plots and serve them as images.

- New MatplotlibWidget.jsx to display plots in the frontend.

- Added a sample sine wave plot for testing.