### PR TITLE
chore(deps): add matplotlib to core dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,7 @@ CORE_DEPENDENCIES = [
     "fastapi>=0.68.0,<1.0.0; platform_system != 'Emscripten'",
     "uvicorn>=0.15.0,<1.0.0; platform_system != 'Emscripten'",
     "websockets>=10.0,<11.0; platform_system != 'Emscripten'",
+    "matplotlib~=3.10.1",
     # Native code dependencies
     "duckdb>=1.1.2; platform_system != 'Emscripten'",
     "scipy>=1.15.2; platform_system != 'Emscripten'",


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to contribute to the project
title: chore(deps): add matplotlib to core dependencies
labels: chore, dependencies
assignees:
---

**Related Issue**
Fixes # (no specific issue — corrective follow-up to merged feature PR)

**Description of Changes**
This PR adds matplotlib to the CORE_DEPENDENCIES list in setup.py. This dependency was missing after a previous feature merge that required matplotlib for server-side rendering, such as figure export in Fastplotlib integration.

The version constraint uses ~= to allow patch-level flexibility, targeting matplotlib~=3.10.1.

**Type of Change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] New example
- [ ] Test improvement

**Testing**
Verified that matplotlib is installed in a fresh virtual environment via pip install -e .

Confirmed no import or runtime errors in backend Fastplotlib functionality

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run my code against examples and ensured no errors
- [x] Any dependent changes have been merged and published in downstream modules