### PR TITLE
fix(setup): add missing fastplotlib and imageio dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,8 @@ CORE_DEPENDENCIES = [
     "matplotlib>=3.8.4",
     # Server-only dependencies
     "fastapi>=0.68.0,<1.0.0; platform_system != 'Emscripten'",
+    "fastplotlib[imgui]~=0.3.0; platform_system != 'Emscripten'",
+    "imageio~=2.37.0; platform_system != 'Emscripten'",
     "uvicorn>=0.15.0,<1.0.0; platform_system != 'Emscripten'",
     "websockets>=10.0,<11.0; platform_system != 'Emscripten'",
     # Native code dependencies


### PR DESCRIPTION
## fix(setup): add missing fastplotlib and imageio dependencies

### Description
This PR adds two missing dependencies to `setup.py`:

- `fastplotlib[imgui]~=0.3.0`
- `imageio~=2.37.0`

These are required to support examples like `hello.py` that use the `fastplotlib` component. Without them, users will encounter import errors when trying to run those examples out of the box.

### Why
Running `preswald run` on the `hello.py` example currently fails unless these dependencies are manually installed. Adding them to `CORE_DEPENDENCIES` ensures a smoother setup experience for users and contributors.

### Checklist
- [x] Added missing dependencies to `setup.py`
- [x] Verified `hello.py` runs successfully with updated install
- [ ] No breaking changes introduced

Let me know if you'd like me to add tests or docs alongside this!
