### PR TITLE
Fix: Use configured port for local deployments

### DIFF
--- a/preswald/deploy.py
+++ b/preswald/deploy.py
@@ -607,7 +607,7 @@ def deploy_to_local(script_path: str, start_port: int = 8501) -> str:
                 "--name",
                 container_name,
                 "-p",
-                f"{port}:{port}",
+                f"{port}:{start_port}",
                 "-v",
                 f"{script_dir}:/app/project",
                 "structuredlabs/preswald-base:latest"

--- a/preswald/deploy.py
+++ b/preswald/deploy.py
@@ -583,14 +583,14 @@ def find_available_port(start_port: int = 8501) -> int:
             port += 1
 
 
-def deploy_to_local(script_path: str) -> str:
+def deploy_to_local(script_path: str, start_port: int = 8501) -> str:
     script_path = os.path.abspath(script_path)
     script_dir = Path(script_path).parent
     container_name = get_container_name(script_path)
     
     try:
         # Find an available port
-        port = find_available_port()
+        port = find_available_port(start_port)
         print(f"\nUsing port: {port}")
         
         # Stop any existing container
@@ -607,7 +607,7 @@ def deploy_to_local(script_path: str) -> str:
                 "--name",
                 container_name,
                 "-p",
-                f"{port}:8501",
+                f"{port}:{port}",
                 "-v",
                 f"{script_dir}:/app/project",
                 "structuredlabs/preswald-base:latest"
@@ -640,7 +640,7 @@ def deploy(  # noqa: C901
     elif target == "gcp":
         return deploy_to_gcp(script_path, port)
     elif target == "local":
-        return deploy_to_local(script_path)
+        return deploy_to_local(script_path, port)
     else:
         raise ValueError(f"Unsupported deployment target: {target}")
 


### PR DESCRIPTION
**Related Issue**
Fixes [#589](https://github.com/StructuredLabs/preswald/issues/589)

**Description of Changes**
This pull request modifies the deployment code under `deploy.py` to pass the configured port from `preswald.toml` into `deploy_to_local`, and ensures that Docker maps the configured port to the corresponding in the container, instead of always searching ports from 8501.

**Type of Change**
- Bug fix (non-breaking change which fixes an issue)

**Testing**
1. Modify the project port in an example project, i.e. `examples/iris` to another port such as 8000
2. Run `preswald deploy` in the example project folder
3. `curl` or visit `http://localhost:8000` in the browser to verify the server is accessible on the configured port

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run my code against examples and ensured no errors
- [x] Any dependent changes have been merged and published in downstream modules