### PR TITLE
Fix/eslint prettier

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -16,6 +16,9 @@ export default [
   },
   {
     files: ['**/*.{js,jsx}'],
+    extends: [
+      'prettier'
+    ],
     languageOptions: {
       ecmaVersion: 2020,
       globals: {
@@ -57,6 +60,20 @@ export default [
         varsIgnorePattern: '^_',
       }],
       'no-console': ['warn', { allow: ['warn', 'error'] }],
+      // Disable ESLint's import ordering to let Prettier handle it
+      'import/order': 'off',
+      ...react.configs['jsx-runtime'].rules,
+      ...reactHooks.configs.recommended.rules,
+      'react/jsx-no-target-blank': 'off',
+      'react-refresh/only-export-components': [
+        'warn',
+        { allowConstantExport: true },
+      ],
+      'no-unused-vars': ['error', {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+      }],
+      'no-console': ['warn', { allow: ['warn', 'error'] }],
       'import/order': ['error', {
         groups: [
           'builtin',
@@ -66,6 +83,11 @@ export default [
           'index',
         ],
         'newlines-between': 'always',
+        pathGroups: [
+          { pattern: '^react', group: 'external', position: 'before' },
+          { pattern: '^@/components/(.*)$', group: 'internal', position: 'before' },
+          { pattern: '^@/(.*)$', group: 'internal' },
+        ],
         alphabetize: {
           order: 'asc',
           caseInsensitive: true,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -67,6 +67,7 @@
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.19.0",
+    "eslint-config-prettier": "^10.1.1",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-react": "^7.37.4",
     "eslint-plugin-react-hooks": "^5.1.0",

--- a/frontend/src/components/DynamicComponents.jsx
+++ b/frontend/src/components/DynamicComponents.jsx
@@ -1,5 +1,13 @@
 import React, { memo, useEffect } from 'react';
 
+// UI components
+import { Alert, AlertDescription } from '@/components/ui/alert';
+
+import { cn } from '@/lib/utils';
+import { comm } from '@/utils/websocket';
+
+// Utilities
+import { createExtractKeyProps } from '../utils/extractKeyProps';
 // Widgets
 import AlertWidget from './widgets/AlertWidget';
 import ButtonWidget from './widgets/ButtonWidget';
@@ -21,14 +29,6 @@ import TableViewerWidget from './widgets/TableViewerWidget';
 import TextInputWidget from './widgets/TextInputWidget';
 import TopbarWidget from './widgets/TopbarWidget';
 import UnknownWidget from './widgets/UnknownWidget';
-
-// Utilities
-import { createExtractKeyProps } from '../utils/extractKeyProps';
-import { comm } from '@/utils/websocket';
-
-// UI components
-import { Alert, AlertDescription } from '@/components/ui/alert';
-import { cn } from '@/lib/utils';
 
 const extractKeyProps = createExtractKeyProps();
 

--- a/frontend/src/components/widgets/FastplotlibWidget.jsx
+++ b/frontend/src/components/widgets/FastplotlibWidget.jsx
@@ -1,7 +1,9 @@
 import PropTypes from 'prop-types';
+
 import React, { useEffect, useState } from 'react';
 
 import { Card } from '@/components/ui/card';
+
 import { cn } from '@/lib/utils';
 import { comm } from '@/utils/websocket';
 
@@ -18,10 +20,7 @@ const FastplotlibWidget = ({ id, label, src, className, clientId }) => {
 
   useEffect(() => {
     const unsubscribe = comm.subscribe((message) => {
-      if (
-        message.type === 'image_update' &&
-        message.component_id === id
-      ) {
+      if (message.type === 'image_update' && message.component_id === id) {
         if (message.value) {
           setCurrentSrc(message.value);
           setHasLoadedOnce(true);
@@ -40,11 +39,7 @@ const FastplotlibWidget = ({ id, label, src, className, clientId }) => {
     <Card className={cn('w-full p-4 flex justify-center items-center relative', className)}>
       {hasLoadedOnce ? (
         <>
-          <img
-            src={currentSrc}
-            alt={label || 'Fastplotlib chart'}
-            className="max-w-full h-auto"
-          />
+          <img src={currentSrc} alt={label || 'Fastplotlib chart'} className="max-w-full h-auto" />
           {showWarning && (
             <div className="absolute bottom-0 left-0 right-0 bg-yellow-100 text-yellow-800 text-xs p-1 text-center">
               Warning: Latest update did not include data.

--- a/frontend/src/components/widgets/SidebarWidget.jsx
+++ b/frontend/src/components/widgets/SidebarWidget.jsx
@@ -1,5 +1,6 @@
 import { HomeIcon } from '@heroicons/react/24/solid';
 import { Menu } from 'lucide-react';
+
 import React, { useState } from 'react';
 import { createPortal } from 'react-dom';
 

--- a/frontend/src/utils/websocket.js
+++ b/frontend/src/utils/websocket.js
@@ -1,4 +1,4 @@
-import { decode } from "@msgpack/msgpack";
+import { decode } from '@msgpack/msgpack';
 
 class WebSocketClient {
   constructor() {
@@ -113,12 +113,14 @@ class WebSocketClient {
             const decoded = decode(new Uint8Array(buffer));
 
             if (decoded?.type === 'image_update' && decoded.format === 'png') {
-
               const { component_id, data: binaryData, label } = decoded;
 
               // Convert image data (Uint8Array) to base64
               const base64 = `data:image/png;base64,${btoa(
-                new Uint8Array(binaryData).reduce((data, byte) => data + String.fromCharCode(byte), '')
+                new Uint8Array(binaryData).reduce(
+                  (data, byte) => data + String.fromCharCode(byte),
+                  ''
+                )
               )}`;
 
               // Update state and notify
@@ -127,17 +129,14 @@ class WebSocketClient {
                 type: 'image_update',
                 component_id,
                 value: base64,
-                label
+                label,
               });
             } else {
               console.warn('[WebSocket] Unknown binary message format:', decoded);
             }
-          }
-
-          else {
+          } else {
             console.warn('[WebSocket] Unrecognized message format:', event.data);
           }
-
         } catch (error) {
           console.error('[WebSocket] Error processing message:', error);
           this._notifySubscribers({
@@ -146,7 +145,6 @@ class WebSocketClient {
           });
         }
       };
-
     } catch (error) {
       console.error('[WebSocket] Error creating connection:', error);
       this.isConnecting = false;


### PR DESCRIPTION
## Description
- For better DX
- ESLint and Prettier config had contradictory rules about file importing

This PR fixes that, #591 

Just another point out to .pre-commit-config.yaml: It stashes the files that I'm not committing over atm, but runs prettier on the files with unstaged changes. This causes new developers when contributing to open-source to get confused since my files were all passing the prettier check; yet failing when pre-commit runs (because the staged changes got stashed).