### PR TITLE
feat: skip reruns in virtual service if no state changes detected

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -62,6 +62,7 @@
         "@vitejs/plugin-react": "^4.3.4",
         "autoprefixer": "^10.4.20",
         "eslint": "^9.19.0",
+        "eslint-config-prettier": "^10.1.1",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-react": "^7.37.4",
         "eslint-plugin-react-hooks": "^5.1.0",
@@ -5819,6 +5820,18 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.1.tgz",
+      "integrity": "sha512-4EQQr6wXwS+ZJSzaR5ZCrYgLxqvUjdXctaEtBqHcbkW944B1NQyO4qpdHQbXBONfwxXdkAY81HH4+LUfrg+zPw==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {

--- a/preswald/browser/virtual_service.py
+++ b/preswald/browser/virtual_service.py
@@ -193,7 +193,6 @@ class VirtualPreswaldService:
 
         def handle_message_from_js(client_id, message_type, data):
             try:
-                from js import Object  # type: ignore
                 import json
 
                 # Convert JsProxy to real Python dict using JSON workaround
@@ -212,9 +211,9 @@ class VirtualPreswaldService:
                 if logger.isEnabledFor(logging.DEBUG):
                     logger.debug(f"Handling JS message from {client_id}: {message}")
 
-                asyncio.create_task(self.handle_client_message(client_id, message))
+                asyncio.create_task(self.handle_client_message(client_id, message))   # noqa: RUF006
                 return True
-            except Exception as e:
+            except Exception:
                 import traceback
                 logger.error("Error in handle_message_from_js: %s", traceback.format_exc())
                 return False
@@ -323,7 +322,7 @@ class VirtualPreswaldService:
         }
 
         if not changed_states:
-            logger.debug(f"[STATE] No actual state changes detected. Skipping rerun.")
+            logger.debug("[STATE] No actual state changes detected. Skipping rerun.")
             return
 
         # Update only changed states

--- a/preswald/browser/virtual_service.py
+++ b/preswald/browser/virtual_service.py
@@ -191,15 +191,33 @@ class VirtualPreswaldService:
         # Create proxies for JavaScript to call Python
         from pyodide.ffi import create_proxy  # type: ignore
 
-        # Handler for incoming messages from JavaScript
         def handle_message_from_js(client_id, message_type, data):
-            """Handle message from JavaScript"""
-            logger.info(f"Received message from JS: {message_type}")
+            try:
+                from js import Object  # type: ignore
+                import json
 
-            # Create a task to handle the message asynchronously
-            message = {"type": message_type, "data": data}
-            asyncio.create_task(self.handle_client_message(client_id, message))  # noqa: RUF006
-            return True
+                # Convert JsProxy to real Python dict using JSON workaround
+                # Note: Although we're on Pyodide 0.27.2, the environment seems to lack `to_py`
+                # likely due to an incomplete or custom Pyodide build
+
+                json_str = window.JSON.stringify(data)
+                py_data = json.loads(json_str)
+
+                if isinstance(py_data, dict):
+                    message = dict(py_data)
+                    message["type"] = message_type
+                else:
+                    message = {"type": message_type, "data": py_data}
+
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(f"Handling JS message from {client_id}: {message}")
+
+                asyncio.create_task(self.handle_client_message(client_id, message))
+                return True
+            except Exception as e:
+                import traceback
+                logger.error("Error in handle_message_from_js: %s", traceback.format_exc())
+                return False
 
         # Export the function to JavaScript
         handle_message_proxy = create_proxy(handle_message_from_js)
@@ -296,17 +314,29 @@ class VirtualPreswaldService:
             await self._send_error(client_id, "Component update missing states")
             raise ValueError("Component update missing states")
 
-        # Update component states
-        self._update_component_states(states)
+        # Only rerun if any state actually changed
+        from preswald.engine.utils import clean_nan_values
+
+        changed_states = {
+            k: v for k, v in states.items()
+            if clean_nan_values(self.get_component_state(k)) != clean_nan_values(v)
+        }
+
+        if not changed_states:
+            logger.debug(f"[STATE] No actual state changes detected. Skipping rerun.")
+            return
+
+        # Update only changed states
+        self._update_component_states(changed_states)
         self._layout_manager.clear_layout()
 
         # Update states and trigger script rerun
         runner = self.script_runners.get(client_id)
         if runner:
-            await runner.rerun(states)
+            await runner.rerun(changed_states)
 
         # Broadcast updates to other clients
-        await self._broadcast_state_updates(states, exclude_client=client_id)
+        await self._broadcast_state_updates(changed_states, exclude_client=client_id)
 
     def _update_component_states(self, states: Dict[str, Any]):
         """Update component states"""

--- a/tests/pyodide_test.html
+++ b/tests/pyodide_test.html
@@ -37,32 +37,34 @@
         // await pyodide.runPythonAsync(`
         //   import micropip
         //   await micropip.install("preswald")
-          
+
         //   # Try importing your modules
         //   import preswald
         //   print("Successfully imported preswald")
-          
+
         //   # Test specific modules/functionality
         //   # import preswald.submodule
         //   # print(preswald.__version__)
         // `);
-        
+
         // Alternative 2: If not published, you can load from wheel
         // First, build your wheel: python -m build --wheel
         // Then serve it locally and load it:
         await pyodide.runPythonAsync(`
           import micropip
-          await micropip.install("http://localhost:8000/preswald-0.1.38-py3-none-any.whl")
+          await micropip.install("http://localhost:8000/dist/preswald-0.1.49-py3-none-any.whl");
           import preswald
           print("Successfully imported from wheel")
-        `);
-        
+          from preswald.engine.service import PreswaldService
+          PreswaldService.initialize()
+    `);
+
         appendOutput("All tests completed!");
       } catch (error) {
         appendOutput("ERROR: " + error);
       }
     }
-    
+
     main();
   </script>
 </body>


### PR DESCRIPTION
**Related Issue**  
Fixes #511 (Fastplotlib WebSocket streaming) — this change builds on that by improving the `virtual_service` behavior

---

**Description of Changes**

- Updates `handle_message_from_js` to reliably convert incoming messages from the browser into Python dicts using a JSON workaround, due to limitations in the available Pyodide build (0.27.2, but missing `to_py`)
- Ensures compatibility with legacy JS message shapes while allowing expanded message structure
- Adds rerun skip logic to `VirtualPreswaldService`: if component state is unchanged, the rerun is skipped and not broadcast to other clients
- Logs a debug message when reruns are skipped due to no actual state change
- Adds `eslint-config-prettier` to `package-lock.json` (already in `devDependencies`) — likely missed in a previous commit

---

**Type of Change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] New example
- [ ] Test improvement

---

**Testing**

Manually tested in the Pyodide virtual environment using `tests/pyodide_test.html` and the browser console to send multiple `component_update` messages. I had to modify pyodide_test.html to explicitly call PreswaldService.initialize() after importing from the wheel. This was necessary because, unlike the entrypoint.py flow which handles service registration and setup automatically, the standalone HTML test does not initialize the virtual service by default. Without calling initialize(), no handlers are registered and handleMessageFromJS is never attached to the window, making interactive testing from the console impossible.

I verified that:

- The first message causes a rerun.
- Re-sending the same message does **not** cause a rerun.
- A new/different message **does** trigger a rerun again.

✅ Screenshot of textarea output in the test page:

![image](https://github.com/user-attachments/assets/372c8de8-eff9-46e0-906c-7aa4ce02dec1)


---

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (N/A here)
- [x] My changes generate no new warnings
- [x] I have run my code against examples and ensured no errors
- [x] Any dependent changes have been merged and published in downstream modules
