### PR TITLE
Preswald Frontend Redesign

### DIFF
--- a/examples/iris/hello.py
+++ b/examples/iris/hello.py
@@ -9,10 +9,13 @@ from preswald import (
     # fastplotlib,
     get_df,
     plotly,
+    sidebar,
     table,
     text,
 )
 
+
+sidebar()
 
 # from preswald.engine.service import PreswaldService
 
@@ -162,7 +165,7 @@ plotly(fig10)
 text(
     "## Sample of the Iris Dataset \n Below is a preview of the first 10 rows of the dataset, showing key measurements for each iris species."
 )
-table(df, limit=10)
+table(df)
 
 # Add an interactive chat interface
 text(

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,8 +1,7 @@
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  width: 100%;
+  margin: 0;
+  padding: 0;
 }
 
 .logo {

--- a/frontend/src/components.css
+++ b/frontend/src/components.css
@@ -8,11 +8,11 @@
 }
 
 .main-content-collapsed-sidebar {
-  @apply lg:pl-20 transition-all duration-300;
+  @apply lg:pl-20 transition-all duration-300 ease-in-out;
 }
 
 .main-content-open-sidebar {
-  @apply lg:pl-80 transition-all duration-300;
+  @apply lg:pl-64 transition-all duration-300 ease-in-out;
 }
 
 .topbar {
@@ -20,15 +20,15 @@
 }
 
 .mobile-menu-button {
-  @apply lg:hidden;
+  @apply fixed left-4 top-4 z-50 lg:hidden h-9 w-9 p-0 flex items-center justify-center;
 }
 
 .desktop-collapse-button {
-  @apply hidden lg:flex;
+  @apply hidden lg:flex absolute -right-4 top-3 h-6 w-6 items-center justify-center rounded-full z-50 translate-x-1/2;
 }
 
 .icon-button {
-  @apply h-6 w-6 transition-transform duration-200;
+  @apply h-4 w-4 transition-transform duration-200;
 }
 
 .separator {
@@ -52,7 +52,7 @@
 }
 
 .sidebar-container {
-  @apply flex grow flex-col h-full;
+  @apply flex grow flex-col gap-4 h-full py-2;
 }
 
 .sidebar-content {
@@ -60,43 +60,47 @@
 }
 
 .sidebar-nav {
-  @apply flex flex-col gap-y-5 w-full;
+  @apply flex flex-col gap-1 w-full;
 }
 
 .sidebar-header {
-  @apply flex h-16 shrink-0 items-center;
+  @apply flex h-16 items-center px-6 mb-2;
+}
+
+.sidebar-logo-container {
+  @apply w-6 h-6 flex items-center justify-center shrink-0;
 }
 
 .sidebar-logo {
-  @apply h-8 w-8;
+  @apply h-6 w-6;
 }
 
 .sidebar-title {
-  @apply ml-4 text-lg font-semibold transition-opacity duration-200;
+  @apply ml-2 text-lg font-medium text-foreground;
 }
 
 .sidebar-nav-list {
-  @apply flex flex-1 flex-col;
+  @apply flex flex-1 flex-col px-4;
 }
 
 .sidebar-nav-items {
-  @apply flex flex-1 flex-col gap-y-7;
+  @apply flex flex-1 flex-col gap-1;
 }
 
 .sidebar-nav-link {
-  @apply flex items-center gap-x-3 rounded-md px-2 py-2 text-sm font-semibold leading-6 transition-all duration-200 m-2;
+  @apply flex items-center gap-x-3 rounded-md px-3 py-2 text-sm text-muted-foreground font-medium transition-colors hover:bg-accent hover:text-accent-foreground;
 }
 
 .sidebar-nav-link-active {
-  @apply bg-accent hover:rounded-md;
+  @apply bg-accent/50 text-foreground;
 }
 
 .sidebar-nav-link-hover {
-  @apply hover:bg-accent;
+  @apply hover:bg-accent hover:text-accent-foreground;
 }
 
 .sidebar-icon {
-  @apply h-6 w-6 shrink-0 transition-transform duration-200;
+  @apply h-4 w-4 shrink-0 opacity-70;
 }
 
 .sidebar-footer {
@@ -109,15 +113,15 @@
 
 /* Mobile Sidebar */
 .sidebar-mobile {
-  @apply fixed inset-y-0 left-0 flex w-[280px] flex-col border-r bg-background p-0;
+  @apply fixed inset-y-0 left-0 flex w-[280px] flex-col bg-background p-0 shadow-lg;
 }
 
 .sidebar-mobile-header {
-  @apply p-4 border-b;
+  @apply flex h-16 items-center px-6 border-b border-border;
 }
 
 .sidebar-mobile-title {
-  @apply flex items-center gap-2;
+  @apply flex items-center gap-3;
 }
 
 .sidebar-mobile-close-btn {
@@ -125,32 +129,32 @@
 }
 
 .sidebar-mobile-content {
-  @apply flex-1 overflow-hidden px-4 py-2;
+  @apply flex-1 overflow-y-auto px-4 py-2;
+}
+
+.sidebar-mobile-logo-container {
+  @apply w-6 h-6 flex items-center justify-center shrink-0;
+}
+
+.sidebar-mobile-name {
+  @apply text-lg font-medium text-foreground;
 }
 
 /* Desktop Sidebar */
 .sidebar-desktop {
-  @apply hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:flex-col border-r bg-background transition-all duration-300 ease-in-out transform-gpu;
+  @apply hidden lg:flex fixed left-0 top-0 h-full flex-col bg-muted/50 transition-all duration-300 ease-in-out z-30 border-r border-border;
 }
 
 .sidebar-desktop-collapsed {
-  @apply lg:w-20 pt-6 items-center gap-y-4;
-}
-
-.sidebar-desktop-collapsed .sidebar-header {
-  @apply justify-center items-center;
+  width: 80px;
 }
 
 .sidebar-desktop-expanded {
-  @apply lg:w-80;
-}
-
-.sidebar-desktop-expanded .desktop-collapse-button {
-  @apply fixed top-6 right-2;
+  width: 256px;
 }
 
 .sidebar-desktop-content {
-  @apply flex-1 overflow-hidden px-4 py-2;
+  @apply flex-1 overflow-hidden px-2 py-2;
 }
 
 .loading-container {
@@ -560,106 +564,6 @@
   @apply text-muted-foreground;
 }
 
-.markdown-container {
-  @apply w-full;
-}
-
-.markdown-card-variant-default {
-  @apply bg-card;
-}
-
-.markdown-card-variant-outline {
-  @apply border rounded-lg;
-}
-
-.markdown-card-variant-ghost {
-  @apply bg-transparent border-none shadow-none;
-}
-
-.markdown-card-content {
-  @apply prose prose-sm md:prose-base lg:prose-lg dark:prose-invert max-w-none;
-}
-
-.markdown-headings {
-  @apply prose-headings:scroll-m-20;
-}
-
-.markdown-paragraph {
-  @apply prose-p:leading-7;
-}
-
-.markdown-list {
-  @apply prose-li:marker:text-muted-foreground;
-}
-
-.markdown-pre {
-  @apply prose-pre:p-0 prose-pre:bg-transparent prose-pre:shadow-lg;
-}
-
-.markdown-code {
-  @apply prose-code:text-zinc-900 dark:prose-code:text-zinc-100;
-}
-
-.markdown-padding {
-  @apply p-0;
-}
-
-.markdown-heading-1 {
-  @apply scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl;
-}
-
-.markdown-heading-2 {
-  @apply scroll-m-20 pb-2 text-3xl font-semibold tracking-tight first:mt-0;
-}
-
-.markdown-heading-3 {
-  @apply scroll-m-20 text-2xl font-semibold tracking-tight;
-}
-
-.markdown-link {
-  @apply font-medium text-primary underline underline-offset-4;
-}
-
-.markdown-pre-wrapper {
-  @apply mb-2 mt-2 overflow-x-auto rounded-lg bg-zinc-950 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 p-4 shadow-sm;
-}
-
-.markdown-inline-code {
-  @apply relative rounded px-[0.3rem] py-[0.2rem] font-mono text-sm bg-zinc-100 dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100 whitespace-normal inline-block;
-}
-
-.markdown-code-lang {
-  @apply absolute right-2 top-2 z-10 rounded-md bg-zinc-700 px-2 py-1 text-xs font-medium text-zinc-200;
-}
-
-.markdown-blockquote {
-  @apply mt-2 border-l-2 pl-6 italic;
-}
-
-.markdown-ul {
-  @apply my-2 ml-6 list-disc [&>li]:mt-2;
-}
-
-.markdown-ol {
-  @apply my-2 ml-6 list-decimal [&>li]:mt-2;
-}
-
-.markdown-table-wrapper {
-  @apply my-4 w-full overflow-y-auto;
-}
-
-.markdown-table {
-  @apply w-full;
-}
-
-.markdown-th {
-  @apply border px-4 py-2 text-left font-bold [&[align=center]]:text-center [&[align=right]]:text-right;
-}
-
-.markdown-td {
-  @apply border px-4 py-2 text-left [&[align=center]]:text-center [&[align=right]]:text-right;
-}
-
 .image-widget-container {
   @apply overflow-hidden;
 }
@@ -831,4 +735,9 @@
 
 .dag-visualizer-tooltip-content {
   @apply text-xs;
+}
+
+/* Platform/Section Headers in Sidebar */
+.sidebar-section-header {
+  @apply px-2 py-4 text-xs font-medium text-muted-foreground/70 uppercase tracking-wider;
 }

--- a/frontend/src/components/DynamicComponents.jsx
+++ b/frontend/src/components/DynamicComponents.jsx
@@ -65,16 +65,7 @@ class ErrorBoundary extends React.Component {
 
 // Memoized component wrapper
 const MemoizedComponent = memo(
-  ({
-    component,
-    index,
-    handleUpdate,
-    extractKeyProps,
-    sidebarOpen,
-    setSidebarOpen,
-    isCollapsed,
-    setIsCollapsed,
-  }) => {
+  ({ component, index, handleUpdate, extractKeyProps }) => {
     const [componentId, componentKey, props] = extractKeyProps(component, index);
 
     switch (component.type) {
@@ -248,12 +239,6 @@ const MemoizedComponent = memo(
             key={componentKey}
             {...props}
             rowData={component.data || []}
-            title={component.title || 'Table Viewer'}
-            variant={component.variant || 'default'}
-            showTitle={component.showTitle ?? true}
-            striped={component.striped ?? true}
-            dense={component.dense ?? false}
-            hoverable={component.hoverable ?? true}
             className={component.className}
           />
         );

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,19 +1,7 @@
 'use client';
 
-import {
-  ChartBarIcon,
-  ClockIcon,
-  DocumentTextIcon,
-  GlobeAltIcon,
-  HomeIcon,
-  MagnifyingGlassIcon,
-  ServerIcon,
-  Squares2X2Icon,
-} from '@heroicons/react/24/solid';
-
 import React, { useState } from 'react';
 import { useEffect } from 'react';
-import { Outlet } from 'react-router-dom';
 
 export default function Layout({ branding, children }) {
   const [faviconLoaded, setFaviconLoaded] = useState(false);
@@ -72,11 +60,9 @@ export default function Layout({ branding, children }) {
 
   return (
     <div className="min-h-screen bg-background">
-      <div id="sidebar-portal" />
-      {/* Main Content */}
-      <div className="flex flex-col min-h-screen main-content-layout">
-        <main className="flex-1 py-10">
-          <div className="px-4 sm:px-6 lg:px-8">{children}</div>
+      <div className="flex min-h-screen relative">
+        <main className="flex-1 main-content-layout relative z-0">
+          <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-10">{children}</div>
         </main>
       </div>
     </div>

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -1,11 +1,9 @@
 "use client";
 
-import { X } from "lucide-react";
 import React, { useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
-import { Menu, PanelLeft, PanelLeftClose } from "lucide-react";
+import { PanelLeft, PanelLeftClose } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Sheet,
   SheetContent,
@@ -31,11 +29,13 @@ const Sidebar = ({
         <div className="sidebar-nav">
           {!isMobile && (
             <div className="sidebar-header">
-              <img
-                className="sidebar-logo"
-                src={`${branding?.logo}?timstamp=${new Date().getTime()}`}
-                alt={branding?.name}
-              />
+              <div className="sidebar-logo-container">
+                <img
+                  className="sidebar-logo"
+                  src={`${branding?.logo}?timstamp=${new Date().getTime()}`}
+                  alt={branding?.name}
+                />
+              </div>
               {!isCollapsed && (
                 <span className="sidebar-title">{branding?.name}</span>
               )}
@@ -87,15 +87,6 @@ const Sidebar = ({
               </li>
             </ul>
           </nav>
-        </div>
-        <div className="sidebar-footer">
-          Built By{" "}
-          <a
-            href="https://github.com/structuredlabs/preswald"
-            className="sidebar-footer-link"
-          >
-            Preswald
-          </a>
         </div>
       </div>
     </div>
@@ -159,11 +150,7 @@ const Sidebar = ({
           onClick={() => setIsCollapsed((prev) => !prev)}
           aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
         >
-          {isCollapsed ? (
-            <PanelLeft className="icon-button" />
-          ) : (
-            <PanelLeftClose className="icon-button" />
-          )}
+          <PanelLeft className="icon-button" />
         </Button>
 
         <div className="sidebar-desktop-content">

--- a/frontend/src/components/widgets/MarkdownRendererWidget.jsx
+++ b/frontend/src/components/widgets/MarkdownRendererWidget.jsx
@@ -10,13 +10,7 @@ import { Card, CardContent } from '@/components/ui/card';
 
 import { cn } from '@/lib/utils';
 
-const MarkdownRendererWidget = ({
-  markdown,
-  value,
-  error,
-  className,
-  variant = 'default', // default, outline, or ghost
-}) => {
+const MarkdownRendererWidget = ({ markdown, value, error, className, variant = 'default' }) => {
   const content = markdown || value || '';
 
   if (error) {
@@ -27,26 +21,24 @@ const MarkdownRendererWidget = ({
     );
   }
 
-  const variantStyles = {
-    default: 'markdown-card-variant-default',
-    outline: 'markdown-card-variant-outline',
-    ghost: 'markdown-card-variant-ghost',
-  };
-
   const components = {
     h1: ({ className, ...props }) => (
-      <h1 className={cn('markdown-heading-1', className)} {...props} />
+      <h1 className={cn('text-4xl font-bold', className)} {...props} />
     ),
     h2: ({ className, ...props }) => (
-      <h2 className={cn('markdown-heading-2', className)} {...props} />
+      <h2 className={cn('text-2xl font-semibold', className)} {...props} />
     ),
     h3: ({ className, ...props }) => (
-      <h3 className={cn('markdown-heading-3', className)} {...props} />
+      <h3 className={cn('text-xl font-semibold', className)} {...props} />
     ),
-    a: ({ className, ...props }) => <a className={cn('markdown-link', className)} {...props} />,
-    pre: ({ className, ...props }) => (
-      <pre className={cn('markdown-pre-wrapper', className)} {...props} />
+    p: ({ className, ...props }) => <p className={cn('leading-7', className)} {...props} />,
+    a: ({ className, ...props }) => (
+      <a
+        className={cn('text-primary hover:text-primary/80 underline underline-offset-4', className)}
+        {...props}
+      />
     ),
+    pre: ({ className, ...props }) => <pre className={cn('rounded-lg', className)} {...props} />,
     code: ({ node, inline, className, children, ...props }) => {
       const match = /language-(\w+)/.exec(className || '');
       const lang = match ? match[1] : '';
@@ -54,7 +46,10 @@ const MarkdownRendererWidget = ({
 
       if (isInline) {
         return (
-          <code className={cn('markdown-inline-code', className)} {...props}>
+          <code
+            className={cn('rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm', className)}
+            {...props}
+          >
             {children}
           </code>
         );
@@ -62,11 +57,19 @@ const MarkdownRendererWidget = ({
 
       return (
         <div className="relative">
-          {lang && <div className="markdown-code-lang">{lang}</div>}
+          {lang && (
+            <div className="absolute right-3 top-2 z-20 text-xs text-muted-foreground">{lang}</div>
+          )}
           <SyntaxHighlighter
             language={lang}
             style={oneDark}
-            customStyle={{ margin: 0, borderRadius: '0.5rem', background: 'rgb(24 24 27)' }}
+            customStyle={{
+              margin: 0,
+              borderRadius: '0.5rem',
+              background: 'rgb(24 24 27)',
+              padding: '1rem',
+              fontSize: '0.875rem',
+            }}
           >
             {String(children).replace(/\n$/, '')}
           </SyntaxHighlighter>
@@ -74,27 +77,28 @@ const MarkdownRendererWidget = ({
       );
     },
     blockquote: ({ className, ...props }) => (
-      <blockquote className={cn('markdown-blockquote', className)} {...props} />
+      <blockquote className={cn('border-l-2 border-border pl-6 italic', className)} {...props} />
     ),
-    ul: ({ className, ...props }) => <ul className={cn('markdown-ul', className)} {...props} />,
-    ol: ({ className, ...props }) => <ol className={cn('markdown-ol', className)} {...props} />,
+    ul: ({ className, ...props }) => <ul className={cn('list-disc pl-6', className)} {...props} />,
+    ol: ({ className, ...props }) => (
+      <ol className={cn('list-decimal pl-6', className)} {...props} />
+    ),
     table: ({ className, ...props }) => (
-      <div className="markdown-table-wrapper">
-        <table className={cn('markdown-table', className)} {...props} />
+      <div className="overflow-x-auto">
+        <table className={cn('w-full', className)} {...props} />
       </div>
     ),
-    th: ({ className, ...props }) => <th className={cn('markdown-th', className)} {...props} />,
-    td: ({ className, ...props }) => <td className={cn('markdown-td', className)} {...props} />,
+    th: ({ className, ...props }) => (
+      <th className={cn('border px-3 py-2 text-left font-semibold', className)} {...props} />
+    ),
+    td: ({ className, ...props }) => (
+      <td className={cn('border px-3 py-2', className)} {...props} />
+    ),
   };
 
   return (
-    <Card className={cn('markdown-container', variantStyles[variant], className)}>
-      <CardContent
-        className={cn(
-          'markdown-card-content markdown-headings markdown-paragraph markdown-list markdown-pre markdown-code',
-          variant === 'ghost' ? 'p-0' : 'markdown-padding'
-        )}
-      >
+    <Card className={cn('overflow-hidden', className)}>
+      <CardContent className={cn('prose prose-stone dark:prose-invert max-w-none')}>
         <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
           {content}
         </ReactMarkdown>

--- a/frontend/src/components/widgets/SidebarWidget.jsx
+++ b/frontend/src/components/widgets/SidebarWidget.jsx
@@ -2,48 +2,39 @@ import { HomeIcon } from '@heroicons/react/24/solid';
 import { Menu } from 'lucide-react';
 
 import React, { useState } from 'react';
-import { createPortal } from 'react-dom';
 
 import { Button } from '@/components/ui/button';
 import { Sidebar } from '@/components/ui/sidebar';
 
-const navigation = [{ name: 'Dashboard', href: '/', icon: HomeIcon }];
+const navigation = [
+  { name: 'Dashboard', href: '/', icon: HomeIcon },
+  // Add more navigation items here as needed
+];
 
 const SidebarWidget = ({ defaultOpen = false, ...props }) => {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [isCollapsed, setIsCollapsed] = useState(!defaultOpen);
 
-  const MobileMenuButton = () => {
-    return (
+  return (
+    <>
       <Button
-        variant="ghost"
+        variant="outline"
         size="icon"
-        className="mobile-menu-button"
+        className="fixed left-4 top-4 z-50 lg:hidden"
         onClick={() => setSidebarOpen(true)}
         aria-label="Open sidebar"
       >
-        <Menu className="icon-button" />
+        <Menu className="h-4 w-4" />
       </Button>
-    );
-  };
 
-  return (
-    <>
-      {document.getElementById('mobile-menu-button-portal') &&
-        createPortal(<MobileMenuButton />, document.getElementById('mobile-menu-button-portal'))}
-
-      {document.getElementById('sidebar-portal') &&
-        createPortal(
-          <Sidebar
-            sidebarOpen={sidebarOpen}
-            setSidebarOpen={setSidebarOpen}
-            isCollapsed={isCollapsed}
-            setIsCollapsed={setIsCollapsed}
-            navigation={navigation}
-            branding={window.PRESWALD_BRANDING}
-          />,
-          document.getElementById('sidebar-portal')
-        )}
+      <Sidebar
+        sidebarOpen={sidebarOpen}
+        setSidebarOpen={setSidebarOpen}
+        isCollapsed={isCollapsed}
+        setIsCollapsed={setIsCollapsed}
+        navigation={navigation}
+        branding={window.PRESWALD_BRANDING}
+      />
     </>
   );
 };

--- a/frontend/src/components/widgets/TableViewerWidget.jsx
+++ b/frontend/src/components/widgets/TableViewerWidget.jsx
@@ -4,160 +4,65 @@ import 'ag-grid-community/styles/ag-grid.css';
 import 'ag-grid-community/styles/ag-theme-alpine.css';
 import { AgGridReact } from 'ag-grid-react';
 
-import React, { useEffect, useRef, useState } from 'react';
+import React from 'react';
 
 ModuleRegistry.registerModules([ClientSideRowModelModule]);
 
 const TableViewerWidget = ({
   rowData = [],
-  title = 'Table Viewer',
-  variant = 'default',
-  showTitle = true,
-  striped = true,
-  dense = false,
-  hoverable = true,
+  hasCard = false,
   className = '',
   pagination = true,
   paginationPageSize = 20,
-  props: { rowData: propsRowData = [], columnDefs: propsColumnDefs = [], title: propsTitle } = {},
+  props: { rowData: propsRowData = [], columnDefs: propsColumnDefs = [] } = {},
   ...commonProps
 }) => {
-  console.log('Received props:', { rowData, propsRowData, propsColumnDefs, title, propsTitle });
-
-  const [isExpanded, setIsExpanded] = useState(true);
-  const gridRef = useRef(null); // Reference for grid API
-
-  // Convert columnDefs to use '/' instead of '.' and add valueFormatter
-  const transformedColumnDefs = propsColumnDefs.map((col) => ({
+  const columns = propsColumnDefs.map((col) => ({
     ...col,
     field: col.field.replace(/\./g, '/'),
-    valueFormatter: (params) =>
-      params.value === '' || params.value === null ? 'null' : params.value,
-    sortable: true, // Enable sorting
-    filter: true, // Enable filtering
-    resizable: true, // Enable column resizing
+    valueFormatter: (params) => params.value ?? 'null',
+    sortable: true,
+    filter: true,
+    resizable: true,
   }));
 
-  // Convert grid data keys to use '/' instead of '.' and replace empty strings with null
-  const transformGridData = (data) => {
-    return data.map((row) => {
-      const newRow = {};
-      for (const key in row) {
-        if (row.hasOwnProperty(key)) {
-          const newKey = key.replace(/\./g, '/');
-          const value = row[key] === '' ? null : String(row[key]);
-          newRow[newKey] = value;
-        }
-      }
-      return newRow;
+  const data = (propsRowData.length ? propsRowData : rowData).map((row) => {
+    const newRow = {};
+    Object.entries(row).forEach(([key, value]) => {
+      newRow[key.replace(/\./g, '/')] = value ?? null;
     });
-  };
-
-  const [gridData, setGridData] = useState(
-    transformGridData(propsRowData.length ? propsRowData : rowData)
-  );
-  const [columnDefs, setColumnDefs] = useState(transformedColumnDefs);
-
-  useEffect(() => {
-    setGridData(transformGridData(propsRowData.length ? propsRowData : rowData));
-    setColumnDefs(transformedColumnDefs);
-  }, [propsRowData, rowData, propsColumnDefs]);
-
-  const displayTitle = propsTitle !== undefined ? propsTitle : title;
-
-  // Export data to CSV (AG Grid Community supports this)
-  const exportToCSV = () => {
-    gridRef.current.api.exportDataAsCsv();
-  };
+    return newRow;
+  });
 
   return (
     <div
-      style={{
-        width: '100%',
-        margin: '1rem 0',
-        borderRadius: '8px',
-        overflow: 'hidden',
-        border: variant === 'card' ? '1px solid #e0e0e0' : 'none',
-        boxShadow: variant === 'card' ? '0 2px 4px rgba(0,0,0,0.1)' : 'none',
-      }}
-      className={`ag-theme-alpine ${className}`}
+      className={`w-full my-4 rounded-sm overflow-hidden ${
+        hasCard ? 'border border-gray-50 shadow-sm bg-white' : ''
+      } ag-theme-alpine ${className} [&_.ag-row-alt]:bg-white`}
     >
-      {showTitle && (
-        <div
-          style={{
-            padding: '1rem',
-            backgroundColor: '#f8f9fa',
-            borderBottom: '1px solid #e0e0e0',
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-          }}
-        >
-          <h3 style={{ margin: 0, fontSize: '1.25rem' }}>{displayTitle}</h3>
-          <div>
-            <button onClick={exportToCSV} style={{ marginRight: '10px' }}>
-              Export CSV
-            </button>
-          </div>
-          <button
-            onClick={() => setIsExpanded(!isExpanded)}
-            style={{
-              background: 'none',
-              border: 'none',
-              cursor: 'pointer',
-              fontSize: '1.2rem',
-            }}
-          >
-            {isExpanded ? '🔼' : '🔽'}
-          </button>
-        </div>
-      )}
-
-      <div
-        style={{
-          height: isExpanded ? '500px' : '0',
-          transition: 'height 0.3s ease-in-out',
-          overflow: 'hidden',
-        }}
-      >
-        {gridData.length > 0 && columnDefs.length > 0 ? (
+      <div className="h-[500px]">
+        {data.length > 0 && columns.length > 0 ? (
           <AgGridReact
-            ref={gridRef}
-            columnDefs={columnDefs}
-            rowData={gridData}
+            columnDefs={columns}
+            rowData={data}
             defaultColDef={{
               sortable: true,
               filter: true,
               resizable: true,
               flex: 1,
             }}
-            rowSelection="multiple" // Enable row selection
             pagination={pagination}
             paginationPageSize={paginationPageSize}
-            suppressRowHoverHighlight={!hoverable}
-            getRowStyle={(params) => ({
-              backgroundColor: striped && params.node.rowIndex % 2 === 0 ? '#f8f9fa' : 'white',
+            getRowStyle={() => ({
+              backgroundColor: 'white',
             })}
-            rowHeight={dense ? 40 : 50}
-            animateRows={true} // Enable smooth animations
-            enableRangeSelection={true} // Allow cell range selection
-            enableSorting={true} // Enable sorting
-            enableFilter={true} // Enable filtering
-            suppressMovableColumns={false} // Allow column reordering
-            enableCellTextSelection={true} // Allow text selection in cells
+            rowHeight={36}
+            headerHeight={28}
             onGridReady={(params) => params.api.sizeColumnsToFit()}
-            onFirstDataRendered={(params) => params.api.sizeColumnsToFit()}
             {...commonProps}
           />
         ) : (
-          <div
-            style={{
-              padding: '2rem',
-              textAlign: 'center',
-              color: '#6c757d',
-              backgroundColor: '#f8f9fa',
-            }}
-          >
+          <div className="p-10 text-center text-gray-500 bg-gray-50 text-sm">
             No data available to display
           </div>
         )}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -28,8 +28,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }

--- a/preswald/__init__.py
+++ b/preswald/__init__.py
@@ -1,5 +1,5 @@
 # Initialize the Preswald package
-__version__ = "0.1.49"
+__version__ = "0.1.50"
 
 from . import interfaces as _interfaces
 from .interfaces import *  # noqa: F403

--- a/preswald/interfaces/components.py
+++ b/preswald/interfaces/components.py
@@ -578,7 +578,7 @@ def spinner(label: str, size: float = 1.0):
     return component
 
 
-def sidebar(defaultopen: bool):
+def sidebar(defaultopen: bool = False):
     """Create a sidebar component."""
     service = PreswaldService.get_instance()
     id = generate_id("sidebar")

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ DEV_DEPENDENCIES = [
 setup(
     # Basic package metadata
     name="preswald",
-    version="0.1.49",
+    version="0.1.50",
     author="Structured Labs",
     author_email="founders@structuredlabs.com",
     description="A lightweight data workflow SDK.",


### PR DESCRIPTION
- cleans up layout styles in `App.css`, removes extra padding/margins, centers content
- redesigns the sidebar (mobile + desktop): collapsible behavior, new layout, styling tweaks, removes old portal logic
- rewrites `ChatWidget`: adds settings toggle for API key input, improves empty/error states, better loading indicators
- simplifies `TableViewerWidget`: cleaner structure, removes title/export logic, responsive layout with better default sizing
- updates `MarkdownRendererWidget`: strips out legacy markdown classes, uses cleaner tailwind prose styling
- removes redundant markdown styles from `components.css`
- adjusts layout structure in `Layout.jsx`: removes sidebar portal logic, simplifies flex structure
- bumps version to `0.1.50`

cleaner UI across the board + smaller bundle from removing legacy styles/components.