### PR TITLE
fix: incorrect table initial column widths

### DIFF
--- a/frontend/src/components/widgets/TableViewerWidget.jsx
+++ b/frontend/src/components/widgets/TableViewerWidget.jsx
@@ -49,7 +49,8 @@ const TableViewerWidget = ({
               sortable: true,
               filter: true,
               resizable: true,
-              flex: 1,
+              minWidth: 100,
+              suppressSizeToFit: false,
             }}
             pagination={pagination}
             paginationPageSize={paginationPageSize}
@@ -58,7 +59,10 @@ const TableViewerWidget = ({
             })}
             rowHeight={36}
             headerHeight={28}
-            onGridReady={(params) => params.api.sizeColumnsToFit()}
+            onGridReady={(params) => {
+              params.api.sizeColumnsToFit();
+              params.columnApi.autoSizeAllColumns();
+            }}
             {...commonProps}
           />
         ) : (


### PR DESCRIPTION
**Description of Changes**
Sets an initial minimum column width of 100px (still resizeable) to prevent squashed columns.
## Before
![Screenshot 2025-04-04 022836](https://github.com/user-attachments/assets/9d0b98f0-7010-49f9-87d9-c5504f3d61fa)
## After
![Screenshot 2025-04-04 023632](https://github.com/user-attachments/assets/09bf45c3-e357-4038-8df3-39194c18b6e0)

**Type of Change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] New example
- [ ] Test improvement

**Testing**
Tested all 4 examples but only earthquake (and potentially similar) example with multiple columns exceeding screen width have the problem

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run my code against examples and ensured no errors
- [x] Any dependent changes have been merged and published in downstream modules