### PR TITLE
Fix query playground

### DIFF
--- a/frontend/src/components/DynamicComponents.jsx
+++ b/frontend/src/components/DynamicComponents.jsx
@@ -274,6 +274,7 @@ const MemoizedComponent = memo(
             value={component.value}
             onChange={(value) => handleUpdate(componentId, value)}
             error={component.error}
+            data={component.data}
           />
         );
 

--- a/frontend/src/components/widgets/PlaygroundWidget.jsx
+++ b/frontend/src/components/widgets/PlaygroundWidget.jsx
@@ -1,20 +1,80 @@
+import Editor from '@monaco-editor/react';
+import { ChevronLeftIcon, ChevronRightIcon, PlayIcon } from '@radix-ui/react-icons';
+
 import React, { useEffect, useState } from 'react';
 
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+const ROWS_PER_PAGE = 10;
+
+const editorOptions = {
+  minimap: { enabled: false },
+  fontSize: 14,
+  lineNumbers: 'on',
+  folding: false,
+  lineDecorationsWidth: 12,
+  lineNumbersMinChars: 2,
+  renderLineHighlight: 'none',
+  overviewRulerBorder: false,
+  hideCursorInOverviewRuler: true,
+  overviewRulerLanes: 0,
+  glyphMargin: false,
+  scrollbar: {
+    vertical: 'hidden',
+    horizontal: 'hidden',
+  },
+  scrollBeyondLastLine: false,
+  wordWrap: 'on',
+  padding: { top: 8, bottom: 8 },
+  suggest: {
+    showKeywords: false,
+  },
+  quickSuggestions: false,
+  parameterHints: {
+    enabled: false,
+  },
+  codeLens: false,
+  contextmenu: false,
+  links: false,
+  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+};
 
 export default function PlaygroundWidget({
-  label = 'Playground Widget',
+  label = 'SQL Playground',
   value,
   onChange,
   source,
   id,
   error,
+  data = null,
 }) {
   const [query, setQuery] = useState();
+  const [currentPage, setCurrentPage] = useState(1);
+
+  // Process the data to get column definitions and row data
+  const columnDefs = data?.columnDefs || [];
+  const rowData = data?.rowData || [];
+
+  // Calculate pagination
+  const totalPages = Math.ceil(rowData.length / ROWS_PER_PAGE);
+  const startIndex = (currentPage - 1) * ROWS_PER_PAGE;
+  const endIndex = startIndex + ROWS_PER_PAGE;
+  const currentRows = rowData.slice(startIndex, endIndex);
 
   function handleQueryRun() {
     onChange?.(query);
+    setCurrentPage(1); // Reset to first page on new query
   }
 
   useEffect(() => {
@@ -22,24 +82,105 @@ export default function PlaygroundWidget({
   }, [value]);
 
   return (
-    <div className="flex flex-col gap-2">
-      <h1 className="text-xl font-semibold">{label}</h1>
-      <h2>Source Used: {source ? source : 'All (By Default)'}</h2>
-      <Input
-        onChange={(e) => setQuery(e.target.value)}
-        placeholder={'Please enter a query'}
-        value={query}
-        id={id}
-        name={id}
-        className="w-full min-w-full py-2 mt-4 rounded"
-      />
-      <Button
-        onClick={handleQueryRun}
-        className="ml-auto py-2 px-2 bg-black hover:bg-neutral-800 text-white rounded"
-      >
-        Run Query
-      </Button>
-      {error && <h3 className="text-red-500">{error}</h3>}
+    <div className="border rounded-md border-gray-200">
+      <Card className="w-full border-0 shadow-none">
+        <CardHeader className="space-y-1">
+          <div className="flex items-center justify-between">
+            <div className="space-y-1">
+              <CardTitle>{label}</CardTitle>
+            </div>
+            <Button onClick={handleQueryRun} size="sm" className="bg-primary hover:bg-primary/90">
+              <PlayIcon className="mr-2 h-4 w-4" />
+              Run Query
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-0 p-0">
+          <div className="border-y bg-white">
+            <Editor
+              height="120px"
+              defaultLanguage="sql"
+              value={query}
+              onChange={setQuery}
+              theme="vs"
+              options={editorOptions}
+              loading=""
+            />
+          </div>
+
+          {error ? (
+            <div className="p-6">
+              <Alert variant="destructive">
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            </div>
+          ) : (
+            <div>
+              <div className="overflow-hidden">
+                <Table>
+                  <TableHeader>
+                    <TableRow className="border-b border-gray-200">
+                      {columnDefs.map((col) => (
+                        <TableHead key={col.field} className="font-semibold bg-white">
+                          {col.headerName}
+                        </TableHead>
+                      ))}
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {currentRows.map((row, i) => (
+                      <TableRow key={i} className="border-b border-gray-200 last:border-0">
+                        {columnDefs.map((col) => (
+                          <TableCell key={col.field}>{row[col.field] ?? 'null'}</TableCell>
+                        ))}
+                      </TableRow>
+                    ))}
+                    {rowData.length === 0 && (
+                      <TableRow>
+                        <TableCell
+                          colSpan={columnDefs.length || 1}
+                          className="h-24 text-center text-muted-foreground"
+                        >
+                          No results
+                        </TableCell>
+                      </TableRow>
+                    )}
+                  </TableBody>
+                </Table>
+              </div>
+              {totalPages > 1 && (
+                <div className="flex items-center justify-between px-4 py-2 border-t border-gray-200 bg-white">
+                  <p className="text-sm text-muted-foreground">
+                    Showing {startIndex + 1}-{Math.min(endIndex, rowData.length)} of{' '}
+                    {rowData.length} results
+                  </p>
+                  <div className="flex items-center space-x-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
+                      disabled={currentPage === 1}
+                    >
+                      <ChevronLeftIcon className="h-4 w-4" />
+                    </Button>
+                    <div className="text-sm text-muted-foreground">
+                      Page {currentPage} of {totalPages}
+                    </div>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setCurrentPage((prev) => Math.min(totalPages, prev + 1))}
+                      disabled={currentPage === totalPages}
+                    >
+                      <ChevronRightIcon className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
         "@ag-grid-community/client-side-row-model": "^32.3.4",
         "@ag-grid-community/core": "^32.3.4",
         "@ag-grid-enterprise/all-modules": "^27.3.0",
+        "@monaco-editor/react": "^4.7.0",
         "ag-grid-react": "^32.3.4",
         "highlight.js": "^11.11.1"
       },
@@ -526,6 +527,29 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.5.0.tgz",
+      "integrity": "sha512-hKoGSM+7aAc7eRTRjpqAZucPmoNOC4UUbknb/VNoTkEIkCPhqV8LfbsgM1webRM7S/z21eHEx9Fkwx8Z/C/+Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@trivago/prettier-plugin-sort-imports": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-5.2.2.tgz",
@@ -665,6 +689,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/monaco-editor": {
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -742,6 +773,12 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
       "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
       "peer": true
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@ag-grid-community/client-side-row-model": "^32.3.4",
     "@ag-grid-community/core": "^32.3.4",
     "@ag-grid-enterprise/all-modules": "^27.3.0",
+    "@monaco-editor/react": "^4.7.0",
     "ag-grid-react": "^32.3.4",
     "highlight.js": "^11.11.1"
   }


### PR DESCRIPTION
- refactors `PlaygroundWidget` UI to use `Card`, `Editor`, and paginated `Table`
- adds support for showing query results with column headers and rows
- adds pagination logic (10 rows per page)
- runs query on button click and resets page to 1
- displays query errors using `Alert` component
- adds `@monaco-editor/react` for SQL editing UI
- backend now serializes DataFrame to `columnDefs` + `rowData` format
- handles NaNs, None, and NumPy types during serialization

https://github.com/user-attachments/assets/e6c5e15b-f1c3-493f-849e-51d298c0a3ef

