### PR TITLE
Feature/preswald export

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,11 @@ We recommend using Conda to manage dependencies:
    ```
    pre-commit install
    ```
+5. Install Playwright Browsers
+Required for saving webpages
+```bash
+playwright install
+```
 
 ### 3. Build the Frontend
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,11 +64,6 @@ We recommend using Conda to manage dependencies:
    ```
    pre-commit install
    ```
-5. Install Playwright Browsers
-Required for saving webpages
-```bash
-playwright install
-```
 
 ### 3. Build the Frontend
 
@@ -89,6 +84,13 @@ Verify your setup by running the sample app:
 ```bash
 cd examples/iris && preswald run
 ```
+### 5. Install Playwright Browsers
+
+Required for saving webpages
+```bash
+playwright install
+```
+
 
 ## Development Workflow
 

--- a/preswald/cli.py
+++ b/preswald/cli.py
@@ -5,6 +5,7 @@ import tempfile
 import click
 
 from preswald.engine.telemetry import TelemetryService
+from preswald.util.exporter import export_html_sync , export_pdf_sync
 
 
 # Create a temporary directory for IPC
@@ -163,6 +164,44 @@ def run(port, log_level, disable_new_tab):
 
     except Exception as e:
         click.echo(f"Error: {e}")
+
+
+@cli.command("export")
+@click.option(
+    "--format",
+    type=click.Choice(["html","pdf"], case_sensitive=False),
+    default="html",
+    help="Format to export the app in (currently only HTML and pdf are supported).",
+)
+@click.option(
+    "--output",
+    type=click.Path(),
+    help="Output file for the export.",
+)
+@click.option(
+    "--page",
+    default="http://localhost:8501",
+    help="Page Url to export from (defaults to http://localhost:8501)",
+)
+def export_app(format,output,page):
+    """
+    Export a Preswald app to a static html page
+    """
+    if format=="html":
+        if output is None:
+            output = "./output/report.html"
+        click.echo(f"Exporting app from {page} to {output}")
+        export_html_sync(page, output)
+        click.echo(f"Exported app to {output}")
+    
+    elif format=="pdf":
+        if output is None:
+            output = "./output/report.pdf"
+        click.echo(f"Exporting app from {page} to {output}")
+        export_pdf_sync(page, output)
+        click.echo(f"Exported app to {output}")
+    else:
+        click.echo(f"Error: Format {format} not supported")
 
 
 @cli.command()

--- a/preswald/util/exporter.py
+++ b/preswald/util/exporter.py
@@ -1,0 +1,86 @@
+import asyncio
+import os
+from socket import timeout
+
+from playwright.async_api import async_playwright
+from bs4 import BeautifulSoup
+import requests
+
+
+async def export_to_html(url:str,output_path:str):
+    """Export a Preswald app to a static HTML page."""
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(
+        )
+        page = await browser.new_page(viewport={"width": 1920, "height": 1080}) # Set a reasonable viewport size
+        await page.goto(url)
+        await page.wait_for_selector(".dashboard-container",timeout=50000)
+        curr_height=0
+        max=await page.evaluate("document.body.scrollHeight")
+        while True:
+            if curr_height >= max:
+                break
+            curr_height+=500
+            await page.evaluate(f"window.scrollTo(0, {curr_height})")
+            await page.wait_for_timeout(1000)  # Allow time for lazy loading
+
+        html_content = await page.content()
+        soup = BeautifulSoup(html_content, 'html.parser')
+        for link_tag in soup.find_all("link",rel='stylesheet'):
+            css_url = link_tag['href']
+            if not css_url.startswith(('http://', 'https://')):
+                base_url = url if not url.endswith('/') else url[:-1]
+                css_url = f'{base_url}{css_url}'
+
+            try:
+                response = requests.get(css_url,stream=True)
+                response.raise_for_status()
+                response.encoding='utf-8'
+                style_tag=soup.new_tag("style")
+                style_tag.string=response.text
+                link_tag.replace_with(style_tag)
+            except requests.exceptions.RequestException as e:
+                print(f"Warning: Could not fetch CSS from {css_url}. Error: {e}")
+                continue
+
+        final_html_content=soup.prettify()
+
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "w", encoding="utf-8") as f:
+            f.write(final_html_content)
+        await browser.close()
+
+
+async def export_to_pdf(url: str, output_path: str):
+    """Export a Preswald app to a PDF file."""
+    async with async_playwright() as p:
+        browser = await p.chromium.launch() 
+        page = await browser.new_page(viewport={"width": 1920, "height": 1080})
+        await page.goto(url)
+        await page.wait_for_selector(".dashboard-container",timeout=50000)
+        
+        curr_height=0
+        max=await page.evaluate("document.body.scrollHeight")
+        while True:
+            if curr_height >= max:
+                break
+            curr_height+=500
+            await page.evaluate(f"window.scrollTo(0, {curr_height})")
+            await page.wait_for_timeout(1000)  # Allow time for lazy loading
+        os.makedirs(os.path.dirname(output_path), exist_ok=True) # Ensure directory exists
+        await page.pdf(path=output_path) # Use Playwright's pdf method
+        await browser.close()
+
+ 
+def export_html_sync(url:str,output_path:str):
+    asyncio.run(export_to_html(url,output_path))
+
+
+def export_pdf_sync(url:str,output_path:str):
+    asyncio.run(export_to_pdf(url,output_path))
+
+if __name__ == "main":
+    app_url="http://localhost:8501"
+    output_path="./report.html"
+    export_html_sync(app_url, output_path)
+    print(f"App exported to {output_path}")

--- a/preswald/util/exporter.py
+++ b/preswald/util/exporter.py
@@ -61,7 +61,7 @@ async def export_to_pdf(url: str, output_path: str):
         
         curr_height=0
         max=await page.evaluate("document.body.scrollHeight")
-        while True:
+        while True: 
             if curr_height >= max:
                 break
             curr_height+=500

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ dependencies = [
     "networkx>=3.0",
     "requests>=2.31.0",
     "tomli>=2.0.1",
+    "playwright>=1.51.0",
+    "beautifulsoup4>=4.13.3",
     # Server-only dependencies
     "fastapi>=0.68.0,<1.0.0; platform_system != 'Emscripten'",
     # "fastplotlib[imgui]~=0.3.0; platform_system != 'Emscripten'",


### PR DESCRIPTION
---
name: Pull Request
about: Added preswald export feature to export a webpage to pdf or html
title: Preswald Export Feature
labels: ''
assignees: ''
---

**Related Issue**
Fixed  #525 
Fixed #526 

**Description of Changes**
- Added preswald/utils/exporter.py with functions to export to pdf or html
- Added a command line feature for export to pdf or html in preswald/cli.py
- Added playwright and beautifulsoup4 as dependencies in setup,py
- Changed documentation to include command to install playwright browsers.



**Type of Change**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] New example
- [ ] Test improvement

**Testing**
Testing done for both html and pdf export feature.

https://github.com/user-attachments/assets/06a86def-212e-475a-a652-c37dcc5546fd



**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run my code against examples and ensured no errors
- [x] Any dependent changes have been merged and published in downstream modules


**Acceptance Criteria**

#525

- [x] Add CLI command: preswald export --format pdf --output report.pdf

- [x]  Open the app in a headless browser

- [x]  Wait for it to fully render

- [x]  Capture the page as a high-resolution PDF

- [x]  Should work with local (localhost:8501) or remote (--page) apps

- [ ]  Default output: A4 portrait, margin: 0.5in

#525 

- [x]  Add CLI command: preswald export --format html --output report.html

- [x]  Launches a headless browser (e.g. Playwright) that opens the running app

- [x]  Waits for UI to fully render before snapshotting

- [x]  Captures and saves the DOM and all assets in a self-contained HTML

- [x]  Supports custom --page URL if user wants to export from deployed version

- [x]  Defaults to http://localhost:8501 if no URL is given
