### PR TITLE
Feature/big number metric card

### DIFF
--- a/docs/sdk/big_number.mdx
+++ b/docs/sdk/big_number.mdx
@@ -1,0 +1,46 @@
+---
+title: "big_number"
+icon: "big number"
+description: ""
+---
+
+```python
+big_number(value: str||int||float, label: str, delta: str, delta_color: str||green, icon: str, description: str)
+```
+
+#BigNumber
+The `big_number` function adds a visual highlight of KPIs like total revenue, conversion rate, or average score.
+
+
+## Properties
+
+| Property     | Type                | Required | Default | Description                                                            |
+|--------------|---------------------|--------- |---------|------------------------------------------------------------------------|
+| value        | string|float|int    | Yes      | -       | The Big number to display                                              |
+| label        | string              | Yes      | ''      | Label text for the big number                                          |
+| delta        | string              | Yes      | ''      | This display's the percentage rise or decrease in the metrics          |
+| delta_color  | string              | Yes      | 'green' | This display's the percentage rise or decrease in the color specified  |
+| icon         | string              | Yes      | -       | This is a lucide react icon which is to the right of big number        |
+| description  | string              | No       | -       | The description of the metrics that the big number is representing     |
+
+
+
+## Basic Usage
+
+```python
+import preswald as pw
+
+def app():
+    pw.big_number(value="12345678",label="Nvidia stocks",delta="+4.15%",delta_color="green",icon="User",description="Up by 4.15%")
+
+pw.run(app)
+```
+
+
+
+## Notes
+
+- The big_number() function introduces visual highlight of KPIs like total revenue, conversion rate, or average score.
+- Make sure you provide the value in string ,number or float only.
+- Start the lucide react icon with a capital letter (for ex. if the icon in lucide.dev website is this "chart-no-axes-combined" then your react lucide icon will be "ChartNoAxesCombined")
+- Make sure that the colors that you enter (to delta_color attribute) is present within tailwind css colours

--- a/docs/usage/examples.mdx
+++ b/docs/usage/examples.mdx
@@ -44,7 +44,7 @@ view(data)
 Create an interactive dashboard where users can control how many rows of data to display:
 
 ```python
-from preswald import text, slider, table
+from preswald big_number
 
 text("# Interactive Dashboard")
 
@@ -53,6 +53,22 @@ table(data, limit=rows)
 ```
 
 ---
+
+
+## **Big Number**
+
+To display visual highlight of KPIs like total revenue, conversion rate, or average score in a card format:
+
+```python
+from preswald import big_number
+
+text("# Nvidia Stock Metrics")
+
+big_number(value="12345678",label="Nvidia stocks",delta="+4.15%",delta_color="green",icon="User",description="Up by 4.15%")
+```
+
+---
+
 
 ## Learn More
 

--- a/examples/iris/hello.py
+++ b/examples/iris/hello.py
@@ -12,6 +12,7 @@ from preswald import (
     sidebar,
     table,
     text,
+    big_number,
 )
 
 
@@ -173,3 +174,11 @@ text(
 )
 
 chat("iris_csv")
+
+text(" ")
+
+big_number(value="12345678",label="Nvidia Stock Metrics",delta="-4.15%",delta_color="red",icon="ChartNoAxesCombined",description="Down by 4.15%")
+
+text(" ")
+
+big_number(value="12345678",label="Nvidia Stock Metrics",delta="+4.15%",delta_color="green",icon="ChartNoAxesCombined",description="Up by 4.15%")

--- a/frontend/src/components/DynamicComponents.jsx
+++ b/frontend/src/components/DynamicComponents.jsx
@@ -10,6 +10,7 @@ import { comm } from '@/utils/websocket';
 import { createExtractKeyProps } from '../utils/extractKeyProps';
 // Widgets
 import AlertWidget from './widgets/AlertWidget';
+import BigNumberCard from './widgets/BigNumberCard';
 import ButtonWidget from './widgets/ButtonWidget';
 import ChatWidget from './widgets/ChatWidget';
 import CheckboxWidget from './widgets/CheckboxWidget';
@@ -197,6 +198,20 @@ const MemoizedComponent = memo(
             withCard={component.withCard}
             aspectRatio={component.aspectRatio || 1}
             objectFit={component.objectFit || 'cover'}
+          />
+        );
+
+      case 'big_number_card':
+        return (
+          <BigNumberCard
+            key={componentKey}
+            {...props}
+            value={component.value || 0}
+            label={component.label || ''}
+            delta={component.delta || ''}
+            deltaColor={component.deltaColor || 'green'}
+            icon={component.icon || null}
+            description={component.description || ''}
           />
         );
 

--- a/frontend/src/components/widgets/BigNumberCard.jsx
+++ b/frontend/src/components/widgets/BigNumberCard.jsx
@@ -1,0 +1,62 @@
+import { ArrowDownRight, ArrowUpRight, User } from 'lucide-react';
+import * as LucideIcons from 'lucide-react';
+
+import React from 'react';
+
+const formatNumber = (value) => {
+  if (typeof value === 'string' && /[KMBT]$/.test(value.trim())) {
+    // Already formatted string (like 12.5M), return as-is
+    return value;
+  }
+
+  const num = typeof value === 'string' ? parseFloat(value) : value;
+  if (isNaN(num)) return value;
+  if (num >= 1e12) return (num / 1e12).toFixed(1) + 'T';
+  if (num >= 1e9) return (num / 1e9).toFixed(1) + 'B';
+  if (num >= 1e6) return (num / 1e6).toFixed(1) + 'M';
+  if (num >= 1e3) return (num / 1e3).toFixed(1) + 'K';
+  return num.toString();
+};
+
+const BigNumberCard = ({
+  value,
+  label,
+  delta,
+  deltaColor = 'green',
+  icon = 'User',
+  description = '',
+}) => {
+  const formattedValue = formatNumber(value);
+  const IconComponent = icon && LucideIcons[icon] ? LucideIcons[icon] : User;
+
+  const deltaClass = deltaColor ? `text-${deltaColor}-600` : 'text-green-600';
+
+  return (
+    <div className="bg-white rounded-3xl p-8 w-80 max-w-sm bignumber transition-shadow duration-300 border border-gray-100 shadow-md hover:shadow-lg">
+      <div className="flex flex-col gap-2">
+        {/* Top: Delta */}
+        <div className="flex justify-end">
+          {delta && (
+            <div className={`flex items-center gap-1 ${deltaClass} -mr-4 pl-4`}>
+              {parseFloat(delta) >= 0 ? <ArrowUpRight size={20} /> : <ArrowDownRight size={20} />}
+              <span className="text-sm font-medium">{delta.toString().replace('.', '.')}</span>
+            </div>
+          )}
+        </div>
+
+        {/* Label */}
+        <p className="text-base text-gray-600 text-lg -mt-8 -ml-4">{label}</p>
+
+        {/* Big Number + Icon */}
+        <div className="flex items-center justify-between mt-2">
+          <h2 className="text-4xl font-bold tracking-tight">{formattedValue}</h2>
+          <IconComponent className="text-gray-500 mr-7" size={40} />
+        </div>
+        {/* Description */}
+        {description?.trim() && <p className="text-base text-gray-500 mt-5 -ml-3">{description}</p>}
+      </div>
+    </div>
+  );
+};
+
+export default BigNumberCard;

--- a/preswald/interfaces/__init__.py
+++ b/preswald/interfaces/__init__.py
@@ -5,6 +5,7 @@ Grouping all the user-facing components of the SDK
 
 from .components import (
     alert,
+    big_number,
     button,
     chat,
     checkbox,

--- a/preswald/interfaces/components.py
+++ b/preswald/interfaces/components.py
@@ -297,7 +297,6 @@ def big_number(
         delta_color: Color of the delta indicator ("green", "red", etc.).
         icon: Optional icon name (e.g., "Backpack").
         description: Optional description text.
-        size: Component width (1.0 = full width).
     Returns:
         Dict: Component metadata.
     """

--- a/preswald/interfaces/components.py
+++ b/preswald/interfaces/components.py
@@ -280,6 +280,47 @@ def matplotlib(fig: Optional[plt.Figure] = None, label: str = "plot") -> str:
     return component_id  # Returning ID for potential tracking
 
 
+def big_number(
+    value: int,
+    label: str,
+    delta: str,
+    delta_color: str = "green",
+    icon: Optional[str] = None,
+    description: Optional[str] = None,
+) -> Dict:
+    """
+    Create a big number card component.
+    Args:
+        value: The main numeric value to display.
+        label: A label describing the value.
+        delta: The change in value (e.g., "+455.222%").
+        delta_color: Color of the delta indicator ("green", "red", etc.).
+        icon: Optional icon name (e.g., "Backpack").
+        description: Optional description text.
+        size: Component width (1.0 = full width).
+    Returns:
+        Dict: Component metadata.
+    """
+    service = PreswaldService.get_instance()
+    component_id = generate_id("big_number_card")
+    logger.debug(f"Creating big number card component with id {component_id}")
+
+    component = {
+        "type": "big_number_card",
+        "id": component_id,
+        "value": value,
+        "label": label,
+        "delta": delta,
+        "deltaColor": delta_color,
+        "icon": icon,
+        "description": description,
+    }
+
+    logger.debug(f"Created component: {component}")
+    service.append_component(component)
+    return component
+
+
 def playground(
     label: str, query: str, source: str | None = None, size: float = 1.0
 ) -> pd.DataFrame:


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to contribute to the project
title: 'Big Number Metric Card UI Component'
labels: ''
assignees: ''
---

**Related Issue**
Fixes #627 

**Description of Changes**
- feat: Added the big_number() Metric Card UI Component for the Preswald SDK
- This metric card ui component represents visual highlight of KPIs like total revenue, conversion rate, or average score
- Accepts int, float, or str values. Automatically formats large numbers (e.g., 1200000 → 1.2M).
- The label is displayed above the big number and it accepts str values.
- The delta(which is a color-coded change indicator) is displayed at the top right corner and it accepts str value
- The delta_color accepts str value and accorfing to the color specified delta will be represented 
- The icon accepts str values and you have enter the correct lucide react icon names
- You can also provide a short description about the metrics
- Added new SDK docs in docs/sdk/big_number.mdx
- Includes an example in examples/iris/hello.py
- Documented in preswald/docs/usage/examples.mdx.

**Type of Change**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] New example
- [ ] Test improvement

**Testing**
 - I have tested the component under examples/iris app
 - These are the screen shots of tests that i have conducted: 
     - ![Screenshot (5)](https://github.com/user-attachments/assets/dbed296f-38fd-4dfd-b4ed-1bbb3ca5607f)
     - ![Screenshot (6)](https://github.com/user-attachments/assets/9ffd3140-1593-468b-b4f4-e81b4b22cbdb)
     - ![Screenshot (7)](https://github.com/user-attachments/assets/f31c97b6-8fe2-4bdb-997a-e98c835c3e34)




**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run my code against examples and ensured no errors
- [ ] Any dependent changes have been merged and published in downstream modules