### PR TITLE
Feature: Add API key loading from secrets.toml for chat widget

### DIFF
--- a/docs/sdk/chat.mdx
+++ b/docs/sdk/chat.mdx
@@ -47,6 +47,11 @@ Implemented in `services/openai.js`
 - OpenAI chat completions integration
 - GPT-3.5-turbo implementation
 - Conversation threading support
+- API key can be loaded from secrets.toml project file by adding a [data.openai] field and setting api_key to your API key like so
+```
+[data.openai]
+api_key = "sk-YOUR-KEY"
+```
 
 ## Basic Usage
 

--- a/frontend/src/components/DynamicComponents.jsx
+++ b/frontend/src/components/DynamicComponents.jsx
@@ -218,6 +218,7 @@ const MemoizedComponent = memo(
             {...props}
             sourceId={component.config?.source || null}
             sourceData={component.config?.data || null}
+            apiKey={component.config?.apiKey || null}
             value={component.value || component.state || { messages: [] }}
             onChange={(value) => {
               handleUpdate(componentId, value);

--- a/frontend/src/components/widgets/ChatWidget.jsx
+++ b/frontend/src/components/widgets/ChatWidget.jsx
@@ -14,6 +14,7 @@ import { createChatCompletion } from '@/services/openai';
 const ChatWidget = ({
   sourceId = null,
   sourceData = null,
+  apiKey = null,
   value = { messages: [] },
   onChange,
   className,
@@ -23,9 +24,14 @@ const ChatWidget = ({
   const messagesEndRef = useRef(null);
   const chatContainerRef = useRef(null);
 
+  // Load API key from secrets.toml if present
+  if (apiKey) {
+    sessionStorage.setItem('openai_api_key', apiKey.trim());
+  }
+
   const [inputValue, setInputValue] = useState('');
   const [showSettings, setShowSettings] = useState(false);
-  const [apiKey, setApiKey] = useState('');
+  // const [apiKey, setApiKey] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
   const hasApiKey = useMemo(() => !!sessionStorage.getItem('openai_api_key'), []);

--- a/preswald/interfaces/components.py
+++ b/preswald/interfaces/components.py
@@ -4,24 +4,18 @@ import hashlib
 import io
 import json
 import logging
-import re
 import uuid
 from typing import Dict, List, Optional
 
 # Third-Party
+import fastplotlib as fplt
 import matplotlib.pyplot as plt
+import msgpack
 import numpy as np
 import pandas as pd
+import tomllib
+from PIL import Image
 
-# from PIL import Image
-# try:
-#     import fastplotlib as fplt
-#     import msgpack
-#
-#     FASTPLOTLIB_AVAILABLE = True
-# except ImportError:
-#     FASTPLOTLIB_AVAILABLE = False
-#     fplt = None
 # Internal
 from preswald.engine.service import PreswaldService
 from preswald.interfaces.workflow import Workflow
@@ -53,36 +47,16 @@ def alert(message: str, level: str = "info", size: float = 1.0) -> str:
     return message
 
 
-def button(
-    label: str,
-    variant: str = "default",
-    disabled: bool = False,
-    loading: bool = False,
-    size: float = 1.0,
-) -> bool:
-    """Create a button component that returns True when clicked."""
+# TODO: Add button functionality
+def button(label: str, size: float = 1.0):
+    """Create a button component."""
     service = PreswaldService.get_instance()
-    component_id = generate_id_by_label("button", label)
-
-    # Get current state or use default
-    current_value = service.get_component_state(component_id)
-    if current_value is None:
-        current_value = False
-
-    component = {
-        "type": "button",
-        "id": component_id,
-        "label": label,
-        "variant": variant,
-        "disabled": disabled,
-        "loading": loading,
-        "size": size,
-        "value": current_value,
-        "onClick": True,  # Always enable click handling
-    }
-
+    id = generate_id("button")
+    logger.debug(f"Creating button component with id {id}, label: {label}")
+    component = {"type": "button", "id": id, "label": label, "size": size}
+    logger.debug(f"Created component: {component}")
     service.append_component(component)
-    return current_value
+    return component
 
 
 def chat(source: str, table: Optional[str] = None) -> Dict:
@@ -96,6 +70,16 @@ def chat(source: str, table: Optional[str] = None) -> Dict:
     current_state = service.get_component_state(component_id)
     if current_state is None:
         current_state = {"messages": [], "source": source}
+
+    # Get API key from secrets.toml
+    with open("secrets.toml", "rb") as toml:
+        secrets = tomllib.load(toml)
+
+    if secrets["data"]["openai"]["api_key"]:
+        api_key = secrets["data"]["openai"]["api_key"]
+
+    else:
+        api_key = None
 
     # Get dataframe from source
     df = (
@@ -132,6 +116,7 @@ def chat(source: str, table: Optional[str] = None) -> Dict:
         "config": {
             "source": source,
             "data": serializable_data,
+            "apiKey": api_key,
         },
     }
 
@@ -165,44 +150,38 @@ def checkbox(label: str, default: bool = False, size: float = 1.0) -> bool:
     return current_value
 
 
-# def fastplotlib(fig: "fplt.Figure", size: float = 1.0) -> str:
+# def fastplotlib(fig: fplt.Figure, size: float = 1.0) -> str:
 #     """
 #     Render a Fastplotlib figure and asynchronously stream the resulting image to the frontend.
-#
+
 #     This component leverages Fastplotlib's GPU-accelerated offscreen rendering capabilities.
 #     Rendering and transmission are triggered only when the figure state or the client changes,
 #     ensuring efficient updates. The rendered image is encoded as a PNG and sent to the frontend
 #     via WebSocket using MessagePack.
-#
+
 #     Args:
 #         fig (fplt.Figure): A configured Fastplotlib figure ready to be rendered.
 #         size (float, optional): Width of the rendered component relative to its container (0.0-1.0).
 #                                 Defaults to 1.0.
-#
+
 #     Returns:
 #         str: A deterministic component ID used to reference the figure on the frontend.
-#
+
 #     Notes:
 #         - The figure must have '_label' and '_client_id' attributes set externally.
 #         - Rendering occurs asynchronously if the figure state or client_id changes.
 #         - If client_id is not provided, a warning is logged and no rendering task is triggered.
 #     """
-#     if not FASTPLOTLIB_AVAILABLE:
-#         logger.warning(
-#             "fastplotlib is not available. Please install it with 'pip install fastplotlib'"
-#         )
-#         return None
-#
 #     service = PreswaldService.get_instance()
-#
+
 #     label = getattr(fig, "_label", "fastplotlib")
 #     component_id = generate_id_by_label("fastplotlib", label)
-#
+
 #     try:
 #         state = fig.get_state()
 #     except Exception:
 #         state = label
-#
+
 #     # hash input data early and use hash to avoid unnecessary rendering
 #     client_id = getattr(fig, "_client_id", None)
 #     hashable_data = {
@@ -212,7 +191,7 @@ def checkbox(label: str, default: bool = False, size: float = 1.0) -> bool:
 #         "size": size,
 #     }
 #     data_hash = hashlib.sha256(msgpack.packb(hashable_data)).hexdigest()
-#
+
 #     component = {
 #         "id": component_id,
 #         "type": "fastplotlib_component",
@@ -222,7 +201,7 @@ def checkbox(label: str, default: bool = False, size: float = 1.0) -> bool:
 #         "value": None,
 #         "hash": data_hash[:8],
 #     }
-#
+
 #     # skip rendering if unchanged
 #     if data_hash != service.get_component_state(f"{component_id}_img_hash"):
 #         if client_id:
@@ -234,7 +213,7 @@ def checkbox(label: str, default: bool = False, size: float = 1.0) -> bool:
 #             )
 #         else:
 #             logger.warning(f"No client_id provided for {component_id}")
-#
+
 #     service.append_component(component)
 #     return component_id
 
@@ -278,106 +257,6 @@ def matplotlib(fig: Optional[plt.Figure] = None, label: str = "plot") -> str:
     service.append_component(component)
 
     return component_id  # Returning ID for potential tracking
-
-
-def playground(
-    label: str, query: str, source: str | None = None, size: float = 1.0
-) -> pd.DataFrame:
-    """
-    Create a playground component for interactive data querying and visualization.
-
-    Args:
-        label (str): The label for the playground component (used for identification).
-        query (str): The SQL query string to be executed.
-        source (str, optional): The name of the data source to query from. All data sources are considered by default.
-        size (float, optional): The visual size/scale of the component. Defaults to 1.0.
-
-    Returns:
-        pd.DataFrame: The queried data as a pandas DataFrame.
-    """
-
-    # Get the singleton instance of the PreswaldService
-    service = PreswaldService.get_instance()
-
-    # Generate a unique component ID using the label's hash
-    component_id = f"playground-{hashlib.md5(label.encode()).hexdigest()[:8]}"
-
-    logger.debug(
-        f"Creating playground component with id {component_id}, label: {label}"
-    )
-
-    # Retrieve the current query state (if previously modified by the user)
-    # If no previous state, use the provided query
-    current_query_value = service.get_component_state(component_id)
-    if current_query_value is None:
-        current_query_value = query
-
-    # Initialize data_source with the provided source or auto-detect it
-    data_source = source
-    if source is None:
-        # Auto-extract the first table name from the SQL query using regex
-        # Handles 'FROM' and 'JOIN' clauses with optional backticks or quotes
-        fetched_sources = re.findall(
-            r'(?:FROM|JOIN)\s+[`"]?([a-zA-Z0-9_\.]+)[`"]?',
-            current_query_value,
-            re.IGNORECASE | re.DOTALL,
-        )
-        # Use the first detected source as the data source
-        data_source = fetched_sources[0] if fetched_sources else None
-
-    # Initialize placeholders for data and error
-    data = None
-    error = None
-    processed_data = None
-    column_defs = []
-
-    # Attempt to execute the query against the determined data source
-    try:
-        data = service.data_manager.query(current_query_value, data_source)
-        logger.debug(f"Successfully queried data source: {data_source}")
-
-        # Process data for the table
-        if isinstance(data, pd.DataFrame):
-            data = data.reset_index(drop=True)
-            processed_data = data.to_dict("records")
-            column_defs = [
-                {"headerName": str(col), "field": str(col)} for col in data.columns
-            ]
-
-            # Process each row to ensure JSON serialization
-            processed_data = []
-            for _, row in data.iterrows():
-                processed_row = {
-                    str(key): (
-                        value.item()
-                        if isinstance(value, (np.integer, np.floating))
-                        else value
-                    )
-                    if value is not None
-                    else ""  # Ensure no None values
-                    for key, value in row.items()
-                }
-                processed_data.append(processed_row)
-    except Exception as e:
-        error = str(e)
-        logger.error(f"Error querying data source: {e}")
-
-    component = {
-        "type": "playground",
-        "id": component_id,
-        "label": label,
-        "source": source,
-        "value": current_query_value,
-        "size": size,
-        "error": error,
-        "data": {"columnDefs": column_defs, "rowData": processed_data or []},
-    }
-
-    logger.debug(f"Created component: {component}")
-    service.append_component(component)
-
-    # Return the raw DataFrame
-    return data
 
 
 def plotly(fig, size: float = 1.0) -> Dict:  # noqa: C901
@@ -609,37 +488,19 @@ def slider(
     return current_value
 
 
-def spinner(
-    label: str = "Loading...",
-    variant: str = "default",
-    show_label: bool = True,
-    size: float = 1.0,
-) -> None:
-    """Create a loading spinner component.
-
-    Args:
-        label: Text to show below the spinner
-        variant: Visual style ("default" or "card")
-        show_label: Whether to show the label text
-        size: Component width (1.0 = full width)
-    """
+# TODO: requires testing
+def spinner(label: str, size: float = 1.0):
+    """Create a spinner component."""
     service = PreswaldService.get_instance()
-    component_id = generate_id("spinner")
-
-    component = {
-        "type": "spinner",
-        "id": component_id,
-        "label": label,
-        "variant": variant,
-        "showLabel": show_label,
-        "size": size,
-    }
-
+    id = generate_id("spinner")
+    logger.debug(f"Creating spinner component with id {id}, label: {label}")
+    component = {"type": "spinner", "id": id, "label": label, "size": size}
+    logger.debug(f"Created component: {component}")
     service.append_component(component)
-    return None
+    return component
 
 
-def sidebar(defaultopen: bool = False):
+def sidebar(defaultopen: bool):
     """Create a sidebar component."""
     service = PreswaldService.get_instance()
     id = generate_id("sidebar")
@@ -650,25 +511,24 @@ def sidebar(defaultopen: bool = False):
     return component
 
 
-def table(
+def table(  # noqa: C901
     data: pd.DataFrame, title: Optional[str] = None, limit: Optional[int] = None
 ) -> Dict:
     """Create a table component that renders data using TableViewerWidget.
 
     Args:
-        data: Pandas DataFrame or list of dictionaries to display.
-        title: Optional title for the table.
-        limit: Optional limit for rows displayed.
+        data: Pandas DataFrame or list of dictionaries to display
+        title: Optional title for the table
 
     Returns:
-        Dict: Component metadata and processed data.
+        Dict: Component metadata and processed data
     """
     id = generate_id("table")
     logger.debug(f"Creating table component with id {id}")
     service = PreswaldService.get_instance()
 
     try:
-        # Convert pandas DataFrame to a list of dictionaries if needed
+        # Convert pandas DataFrame to list of dictionaries if needed
         if hasattr(data, "to_dict"):
             if isinstance(data, pd.DataFrame):
                 data = data.reset_index(drop=True)
@@ -680,49 +540,49 @@ def table(
         if not isinstance(data, list):
             data = [data] if data else []
 
-        # Ensure data is not empty before accessing keys
-        if data and isinstance(data[0], dict):
-            column_defs = [
-                {"headerName": str(col), "field": str(col)} for col in data[0].keys()
-            ]
-        else:
-            column_defs = []
-
-        # Process each row to ensure JSON serialization
+        # Convert each row to ensure JSON serialization
         processed_data = []
         for row in data:
-            processed_row = {
-                str(key): (
-                    value.item()
-                    if isinstance(value, (np.integer, np.floating))
-                    else value
-                )
-                if value is not None
-                else ""  # Ensure no None values
-                for key, value in row.items()
-            }
-            processed_data.append(processed_row)
+            if isinstance(row, dict):
+                processed_row = {}
+                for key, value in row.items():
+                    # Convert key to string to ensure it's serializable
+                    key_str = str(key)
 
-        # Log debug info
-        logger.debug(f"Column Definitions: {column_defs}")
-        logger.debug(
-            f"Processed Data (first 5 rows): {processed_data[:5]}"
-        )  # Limit logs
+                    # Handle special cases and convert value
+                    if pd.isna(value):
+                        processed_row[key_str] = None
+                    elif isinstance(value, (pd.Timestamp, pd.DatetimeTZDtype)):
+                        processed_row[key_str] = str(value)
+                    elif isinstance(value, (np.integer, np.floating)):
+                        processed_row[key_str] = value.item()
+                    elif isinstance(value, (list, np.ndarray)):
+                        processed_row[key_str] = convert_to_serializable(value)
+                    else:
+                        try:
+                            # Try to serialize to test if it's JSON-compatible
+                            json.dumps(value)
+                            processed_row[key_str] = value
+                        except:  # noqa: E722
+                            # If serialization fails, convert to string
+                            processed_row[key_str] = str(value)
+                processed_data.append(processed_row)
+            else:
+                # If row is not a dict, convert it to a simple dict
+                processed_data.append({"value": str(row)})
 
-        # Create AG Grid compatible component structure
+        # Create the component structure
         component = {
             "type": "table",
             "id": id,
-            "props": {
-                "columnDefs": column_defs,
-                "rowData": processed_data,
-                "title": str(title) if title else None,
-            },
+            "data": processed_data,
+            "title": str(title) if title is not None else None,
         }
 
         # Verify JSON serialization before returning
         json.dumps(component)
-        logger.debug(f"Created AG Grid table component: {component}")
+
+        logger.debug(f"Created table component: {component}")
         service.append_component(component)
         return component
 
@@ -731,11 +591,8 @@ def table(
         error_component = {
             "type": "table",
             "id": id,
-            "props": {
-                "columnDefs": [],
-                "rowData": [],
-                "title": f"Error: {e!s}",
-            },
+            "data": [],
+            "title": f"Error: {e!s}",
         }
         service.append_component(error_component)
         return error_component
@@ -758,31 +615,21 @@ def text(markdown_str: str, size: float = 1.0) -> str:
     return markdown_str
 
 
-def text_input(
-    label: str,
-    placeholder: str = "",
-    default: str = "",
-    size: float = 1.0,
-) -> str:
-    """Create a text input component.
-
-    Args:
-        label: Label text shown above the input
-        placeholder: Placeholder text shown when input is empty
-        default: Initial value for the input
-        size: Component width (1.0 = full width)
-
-    Returns:
-        str: Current value of the input
-    """
+def text_input(label: str, placeholder: str = "", size: float = 1.0) -> str:
+    """Create a text input component with consistent ID based on label."""
     service = PreswaldService.get_instance()
+
+    # Create a consistent ID based on the label
     component_id = generate_id_by_label("text_input", label)
 
     # Get current state or use default
     current_value = service.get_component_state(component_id)
     if current_value is None:
-        current_value = default
+        current_value = ""
 
+    logger.debug(
+        f"Creating text input component with id {component_id}, label: {label}"
+    )
     component = {
         "type": "text_input",
         "id": component_id,
@@ -791,7 +638,7 @@ def text_input(
         "value": current_value,
         "size": size,
     }
-
+    logger.debug(f"Created component: {component}")
     service.append_component(component)
     return current_value
 
@@ -922,90 +769,90 @@ def generate_id_by_label(prefix: str, label: str) -> str:
     return f"{prefix}-{hashed}"
 
 
-# async def render_and_send_fastplotlib(
-#     fig: "fplt.Figure",
-#     component_id: str,
-#     label: str,
-#     size: float,
-#     client_id: str,
-#     data_hash: str,
-# ) -> Optional[str]:
-#     """
-#     Asynchronously renders a Fastplotlib figure to an offscreen canvas, encodes it as a PNG,
-#     and streams the resulting image data via WebSocket to the connected frontend client.
-#
-#     This helper function handles rendering logic, alpha-blending, and ensures robust error
-#     handling. It updates the component state after successfully sending the image data.
-#
-#     Args:
-#         fig (fplt.Figure): The fully configured Fastplotlib figure instance to render.
-#         component_id (str): Unique identifier for the component instance receiving this image.
-#         label (str): Human-readable label describing the component (for logging/debugging).
-#         size (float): Relative size of the component in the UI layout (0.0-1.0).
-#         client_id (str): WebSocket client identifier to route the rendered image correctly.
-#         data_hash (str): SHA-256 hash representing the figure state, used for cache invalidation.
-#
-#     Returns:
-#         str: Returns "Render failed" if framebuffer blending fails, otherwise None.
-#
-#     Raises:
-#         Logs and handles any exceptions internally without raising further.
-#     """
-#     service = PreswaldService.get_instance()
-#
-#     fig.show()  # must call even in offscreen mode to initialize GPU resources
-#
-#     # manually render the scene for all subplots
-#     for subplot in fig:
-#         subplot.viewport.render(subplot.scene, subplot.camera)
-#
-#     # read from the framebuffer
-#     try:
-#         fig.canvas.request_draw()
-#         raw_img = np.asarray(fig.renderer.target.draw())
-#
-#         if raw_img.ndim != 3 or raw_img.shape[2] != 4:
-#             raise ValueError(f"Unexpected image shape: {raw_img.shape}")
-#
-#         # handle alpha blending
-#         alpha = raw_img[..., 3:4] / 255.0
-#         rgb = (raw_img[..., :3] * alpha + (1 - alpha) * 255).astype(np.uint8)
-#
-#     except Exception as e:
-#         logger.error(f"Framebuffer blending failed for {component_id}: {e}")
-#         return "Render failed"
-#
-#     # encode image to PNG
-#     img_buf = io.BytesIO()
-#     Image.fromarray(rgb).save(img_buf, format="PNG")
-#     png_bytes = img_buf.getvalue()
-#
-#     # handle websocket communication
-#     client_websocket = service.websocket_connections.get(client_id)
-#     if client_websocket:
-#         packed_msg = msgpack.packb(
-#             {
-#                 "type": "image_update",
-#                 "component_id": component_id,
-#                 "format": "png",
-#                 "label": label,
-#                 "size": size,
-#                 "data": png_bytes,
-#             },
-#             use_bin_type=True,
-#         )
-#
-#         try:
-#             await client_websocket.send_bytes(packed_msg)
-#             await service.handle_client_message(
-#                 client_id,
-#                 {
-#                     "type": "component_update",
-#                     "states": {f"{component_id}_img_hash": data_hash},
-#                 },
-#             )
-#             logger.debug(f"✅ Sent {component_id} image to client {client_id}")
-#         except Exception as e:
-#             logger.error(f"WebSocket send failed for {component_id}: {e}")
-#     else:
-#         logger.warning(f"No active WebSocket found for client ID: {client_id}")
+async def render_and_send_fastplotlib(
+    fig: fplt.Figure,
+    component_id: str,
+    label: str,
+    size: float,
+    client_id: str,
+    data_hash: str,
+) -> Optional[str]:
+    """
+    Asynchronously renders a Fastplotlib figure to an offscreen canvas, encodes it as a PNG,
+    and streams the resulting image data via WebSocket to the connected frontend client.
+
+    This helper function handles rendering logic, alpha-blending, and ensures robust error
+    handling. It updates the component state after successfully sending the image data.
+
+    Args:
+        fig (fplt.Figure): The fully configured Fastplotlib figure instance to render.
+        component_id (str): Unique identifier for the component instance receiving this image.
+        label (str): Human-readable label describing the component (for logging/debugging).
+        size (float): Relative size of the component in the UI layout (0.0-1.0).
+        client_id (str): WebSocket client identifier to route the rendered image correctly.
+        data_hash (str): SHA-256 hash representing the figure state, used for cache invalidation.
+
+    Returns:
+        str: Returns "Render failed" if framebuffer blending fails, otherwise None.
+
+    Raises:
+        Logs and handles any exceptions internally without raising further.
+    """
+    service = PreswaldService.get_instance()
+
+    fig.show()  # must call even in offscreen mode to initialize GPU resources
+
+    # manually render the scene for all subplots
+    for subplot in fig:
+        subplot.viewport.render(subplot.scene, subplot.camera)
+
+    # read from the framebuffer
+    try:
+        fig.canvas.request_draw()
+        raw_img = np.asarray(fig.renderer.target.draw())
+
+        if raw_img.ndim != 3 or raw_img.shape[2] != 4:
+            raise ValueError(f"Unexpected image shape: {raw_img.shape}")
+
+        # handle alpha blending
+        alpha = raw_img[..., 3:4] / 255.0
+        rgb = (raw_img[..., :3] * alpha + (1 - alpha) * 255).astype(np.uint8)
+
+    except Exception as e:
+        logger.error(f"Framebuffer blending failed for {component_id}: {e}")
+        return "Render failed"
+
+    # encode image to PNG
+    img_buf = io.BytesIO()
+    Image.fromarray(rgb).save(img_buf, format="PNG")
+    png_bytes = img_buf.getvalue()
+
+    # handle websocket communication
+    client_websocket = service.websocket_connections.get(client_id)
+    if client_websocket:
+        packed_msg = msgpack.packb(
+            {
+                "type": "image_update",
+                "component_id": component_id,
+                "format": "png",
+                "label": label,
+                "size": size,
+                "data": png_bytes,
+            },
+            use_bin_type=True,
+        )
+
+        try:
+            await client_websocket.send_bytes(packed_msg)
+            await service.handle_client_message(
+                client_id,
+                {
+                    "type": "component_update",
+                    "states": {f"{component_id}_img_hash": data_hash},
+                },
+            )
+            logger.debug(f"✅ Sent {component_id} image to client {client_id}")
+        except Exception as e:
+            logger.error(f"WebSocket send failed for {component_id}: {e}")
+    else:
+        logger.warning(f"No active WebSocket found for client ID: {client_id}")

--- a/preswald/interfaces/components.py
+++ b/preswald/interfaces/components.py
@@ -4,18 +4,25 @@ import hashlib
 import io
 import json
 import logging
+import re
 import uuid
 from typing import Dict, List, Optional
 
 # Third-Party
-import fastplotlib as fplt
 import matplotlib.pyplot as plt
-import msgpack
 import numpy as np
 import pandas as pd
 import tomllib
-from PIL import Image
 
+# from PIL import Image
+# try:
+#     import fastplotlib as fplt
+#     import msgpack
+#
+#     FASTPLOTLIB_AVAILABLE = True
+# except ImportError:
+#     FASTPLOTLIB_AVAILABLE = False
+#     fplt = None
 # Internal
 from preswald.engine.service import PreswaldService
 from preswald.interfaces.workflow import Workflow
@@ -47,16 +54,36 @@ def alert(message: str, level: str = "info", size: float = 1.0) -> str:
     return message
 
 
-# TODO: Add button functionality
-def button(label: str, size: float = 1.0):
-    """Create a button component."""
+def button(
+    label: str,
+    variant: str = "default",
+    disabled: bool = False,
+    loading: bool = False,
+    size: float = 1.0,
+) -> bool:
+    """Create a button component that returns True when clicked."""
     service = PreswaldService.get_instance()
-    id = generate_id("button")
-    logger.debug(f"Creating button component with id {id}, label: {label}")
-    component = {"type": "button", "id": id, "label": label, "size": size}
-    logger.debug(f"Created component: {component}")
+    component_id = generate_id_by_label("button", label)
+
+    # Get current state or use default
+    current_value = service.get_component_state(component_id)
+    if current_value is None:
+        current_value = False
+
+    component = {
+        "type": "button",
+        "id": component_id,
+        "label": label,
+        "variant": variant,
+        "disabled": disabled,
+        "loading": loading,
+        "size": size,
+        "value": current_value,
+        "onClick": True,  # Always enable click handling
+    }
+
     service.append_component(component)
-    return component
+    return current_value
 
 
 def chat(source: str, table: Optional[str] = None) -> Dict:
@@ -75,7 +102,7 @@ def chat(source: str, table: Optional[str] = None) -> Dict:
     with open("secrets.toml", "rb") as toml:
         secrets = tomllib.load(toml)
 
-    if secrets["data"]["openai"]["api_key"]:
+    if secrets and secrets["data"]["openai"]["api_key"]:
         api_key = secrets["data"]["openai"]["api_key"]
 
     else:
@@ -150,38 +177,44 @@ def checkbox(label: str, default: bool = False, size: float = 1.0) -> bool:
     return current_value
 
 
-# def fastplotlib(fig: fplt.Figure, size: float = 1.0) -> str:
+# def fastplotlib(fig: "fplt.Figure", size: float = 1.0) -> str:
 #     """
 #     Render a Fastplotlib figure and asynchronously stream the resulting image to the frontend.
-
+#
 #     This component leverages Fastplotlib's GPU-accelerated offscreen rendering capabilities.
 #     Rendering and transmission are triggered only when the figure state or the client changes,
 #     ensuring efficient updates. The rendered image is encoded as a PNG and sent to the frontend
 #     via WebSocket using MessagePack.
-
+#
 #     Args:
 #         fig (fplt.Figure): A configured Fastplotlib figure ready to be rendered.
 #         size (float, optional): Width of the rendered component relative to its container (0.0-1.0).
 #                                 Defaults to 1.0.
-
+#
 #     Returns:
 #         str: A deterministic component ID used to reference the figure on the frontend.
-
+#
 #     Notes:
 #         - The figure must have '_label' and '_client_id' attributes set externally.
 #         - Rendering occurs asynchronously if the figure state or client_id changes.
 #         - If client_id is not provided, a warning is logged and no rendering task is triggered.
 #     """
+#     if not FASTPLOTLIB_AVAILABLE:
+#         logger.warning(
+#             "fastplotlib is not available. Please install it with 'pip install fastplotlib'"
+#         )
+#         return None
+#
 #     service = PreswaldService.get_instance()
-
+#
 #     label = getattr(fig, "_label", "fastplotlib")
 #     component_id = generate_id_by_label("fastplotlib", label)
-
+#
 #     try:
 #         state = fig.get_state()
 #     except Exception:
 #         state = label
-
+#
 #     # hash input data early and use hash to avoid unnecessary rendering
 #     client_id = getattr(fig, "_client_id", None)
 #     hashable_data = {
@@ -191,7 +224,7 @@ def checkbox(label: str, default: bool = False, size: float = 1.0) -> bool:
 #         "size": size,
 #     }
 #     data_hash = hashlib.sha256(msgpack.packb(hashable_data)).hexdigest()
-
+#
 #     component = {
 #         "id": component_id,
 #         "type": "fastplotlib_component",
@@ -201,7 +234,7 @@ def checkbox(label: str, default: bool = False, size: float = 1.0) -> bool:
 #         "value": None,
 #         "hash": data_hash[:8],
 #     }
-
+#
 #     # skip rendering if unchanged
 #     if data_hash != service.get_component_state(f"{component_id}_img_hash"):
 #         if client_id:
@@ -213,7 +246,7 @@ def checkbox(label: str, default: bool = False, size: float = 1.0) -> bool:
 #             )
 #         else:
 #             logger.warning(f"No client_id provided for {component_id}")
-
+#
 #     service.append_component(component)
 #     return component_id
 
@@ -257,6 +290,106 @@ def matplotlib(fig: Optional[plt.Figure] = None, label: str = "plot") -> str:
     service.append_component(component)
 
     return component_id  # Returning ID for potential tracking
+
+
+def playground(
+    label: str, query: str, source: str | None = None, size: float = 1.0
+) -> pd.DataFrame:
+    """
+    Create a playground component for interactive data querying and visualization.
+
+    Args:
+        label (str): The label for the playground component (used for identification).
+        query (str): The SQL query string to be executed.
+        source (str, optional): The name of the data source to query from. All data sources are considered by default.
+        size (float, optional): The visual size/scale of the component. Defaults to 1.0.
+
+    Returns:
+        pd.DataFrame: The queried data as a pandas DataFrame.
+    """
+
+    # Get the singleton instance of the PreswaldService
+    service = PreswaldService.get_instance()
+
+    # Generate a unique component ID using the label's hash
+    component_id = f"playground-{hashlib.md5(label.encode()).hexdigest()[:8]}"
+
+    logger.debug(
+        f"Creating playground component with id {component_id}, label: {label}"
+    )
+
+    # Retrieve the current query state (if previously modified by the user)
+    # If no previous state, use the provided query
+    current_query_value = service.get_component_state(component_id)
+    if current_query_value is None:
+        current_query_value = query
+
+    # Initialize data_source with the provided source or auto-detect it
+    data_source = source
+    if source is None:
+        # Auto-extract the first table name from the SQL query using regex
+        # Handles 'FROM' and 'JOIN' clauses with optional backticks or quotes
+        fetched_sources = re.findall(
+            r'(?:FROM|JOIN)\s+[`"]?([a-zA-Z0-9_\.]+)[`"]?',
+            current_query_value,
+            re.IGNORECASE | re.DOTALL,
+        )
+        # Use the first detected source as the data source
+        data_source = fetched_sources[0] if fetched_sources else None
+
+    # Initialize placeholders for data and error
+    data = None
+    error = None
+    processed_data = None
+    column_defs = []
+
+    # Attempt to execute the query against the determined data source
+    try:
+        data = service.data_manager.query(current_query_value, data_source)
+        logger.debug(f"Successfully queried data source: {data_source}")
+
+        # Process data for the table
+        if isinstance(data, pd.DataFrame):
+            data = data.reset_index(drop=True)
+            processed_data = data.to_dict("records")
+            column_defs = [
+                {"headerName": str(col), "field": str(col)} for col in data.columns
+            ]
+
+            # Process each row to ensure JSON serialization
+            processed_data = []
+            for _, row in data.iterrows():
+                processed_row = {
+                    str(key): (
+                        value.item()
+                        if isinstance(value, (np.integer, np.floating))
+                        else value
+                    )
+                    if value is not None
+                    else ""  # Ensure no None values
+                    for key, value in row.items()
+                }
+                processed_data.append(processed_row)
+    except Exception as e:
+        error = str(e)
+        logger.error(f"Error querying data source: {e}")
+
+    component = {
+        "type": "playground",
+        "id": component_id,
+        "label": label,
+        "source": source,
+        "value": current_query_value,
+        "size": size,
+        "error": error,
+        "data": {"columnDefs": column_defs, "rowData": processed_data or []},
+    }
+
+    logger.debug(f"Created component: {component}")
+    service.append_component(component)
+
+    # Return the raw DataFrame
+    return data
 
 
 def plotly(fig, size: float = 1.0) -> Dict:  # noqa: C901
@@ -488,19 +621,37 @@ def slider(
     return current_value
 
 
-# TODO: requires testing
-def spinner(label: str, size: float = 1.0):
-    """Create a spinner component."""
+def spinner(
+    label: str = "Loading...",
+    variant: str = "default",
+    show_label: bool = True,
+    size: float = 1.0,
+) -> None:
+    """Create a loading spinner component.
+
+    Args:
+        label: Text to show below the spinner
+        variant: Visual style ("default" or "card")
+        show_label: Whether to show the label text
+        size: Component width (1.0 = full width)
+    """
     service = PreswaldService.get_instance()
-    id = generate_id("spinner")
-    logger.debug(f"Creating spinner component with id {id}, label: {label}")
-    component = {"type": "spinner", "id": id, "label": label, "size": size}
-    logger.debug(f"Created component: {component}")
+    component_id = generate_id("spinner")
+
+    component = {
+        "type": "spinner",
+        "id": component_id,
+        "label": label,
+        "variant": variant,
+        "showLabel": show_label,
+        "size": size,
+    }
+
     service.append_component(component)
-    return component
+    return None
 
 
-def sidebar(defaultopen: bool):
+def sidebar(defaultopen: bool = False):
     """Create a sidebar component."""
     service = PreswaldService.get_instance()
     id = generate_id("sidebar")
@@ -511,24 +662,25 @@ def sidebar(defaultopen: bool):
     return component
 
 
-def table(  # noqa: C901
+def table(
     data: pd.DataFrame, title: Optional[str] = None, limit: Optional[int] = None
 ) -> Dict:
     """Create a table component that renders data using TableViewerWidget.
 
     Args:
-        data: Pandas DataFrame or list of dictionaries to display
-        title: Optional title for the table
+        data: Pandas DataFrame or list of dictionaries to display.
+        title: Optional title for the table.
+        limit: Optional limit for rows displayed.
 
     Returns:
-        Dict: Component metadata and processed data
+        Dict: Component metadata and processed data.
     """
     id = generate_id("table")
     logger.debug(f"Creating table component with id {id}")
     service = PreswaldService.get_instance()
 
     try:
-        # Convert pandas DataFrame to list of dictionaries if needed
+        # Convert pandas DataFrame to a list of dictionaries if needed
         if hasattr(data, "to_dict"):
             if isinstance(data, pd.DataFrame):
                 data = data.reset_index(drop=True)
@@ -540,49 +692,49 @@ def table(  # noqa: C901
         if not isinstance(data, list):
             data = [data] if data else []
 
-        # Convert each row to ensure JSON serialization
+        # Ensure data is not empty before accessing keys
+        if data and isinstance(data[0], dict):
+            column_defs = [
+                {"headerName": str(col), "field": str(col)} for col in data[0].keys()
+            ]
+        else:
+            column_defs = []
+
+        # Process each row to ensure JSON serialization
         processed_data = []
         for row in data:
-            if isinstance(row, dict):
-                processed_row = {}
-                for key, value in row.items():
-                    # Convert key to string to ensure it's serializable
-                    key_str = str(key)
+            processed_row = {
+                str(key): (
+                    value.item()
+                    if isinstance(value, (np.integer, np.floating))
+                    else value
+                )
+                if value is not None
+                else ""  # Ensure no None values
+                for key, value in row.items()
+            }
+            processed_data.append(processed_row)
 
-                    # Handle special cases and convert value
-                    if pd.isna(value):
-                        processed_row[key_str] = None
-                    elif isinstance(value, (pd.Timestamp, pd.DatetimeTZDtype)):
-                        processed_row[key_str] = str(value)
-                    elif isinstance(value, (np.integer, np.floating)):
-                        processed_row[key_str] = value.item()
-                    elif isinstance(value, (list, np.ndarray)):
-                        processed_row[key_str] = convert_to_serializable(value)
-                    else:
-                        try:
-                            # Try to serialize to test if it's JSON-compatible
-                            json.dumps(value)
-                            processed_row[key_str] = value
-                        except:  # noqa: E722
-                            # If serialization fails, convert to string
-                            processed_row[key_str] = str(value)
-                processed_data.append(processed_row)
-            else:
-                # If row is not a dict, convert it to a simple dict
-                processed_data.append({"value": str(row)})
+        # Log debug info
+        logger.debug(f"Column Definitions: {column_defs}")
+        logger.debug(
+            f"Processed Data (first 5 rows): {processed_data[:5]}"
+        )  # Limit logs
 
-        # Create the component structure
+        # Create AG Grid compatible component structure
         component = {
             "type": "table",
             "id": id,
-            "data": processed_data,
-            "title": str(title) if title is not None else None,
+            "props": {
+                "columnDefs": column_defs,
+                "rowData": processed_data,
+                "title": str(title) if title else None,
+            },
         }
 
         # Verify JSON serialization before returning
         json.dumps(component)
-
-        logger.debug(f"Created table component: {component}")
+        logger.debug(f"Created AG Grid table component: {component}")
         service.append_component(component)
         return component
 
@@ -591,8 +743,11 @@ def table(  # noqa: C901
         error_component = {
             "type": "table",
             "id": id,
-            "data": [],
-            "title": f"Error: {e!s}",
+            "props": {
+                "columnDefs": [],
+                "rowData": [],
+                "title": f"Error: {e!s}",
+            },
         }
         service.append_component(error_component)
         return error_component
@@ -615,21 +770,31 @@ def text(markdown_str: str, size: float = 1.0) -> str:
     return markdown_str
 
 
-def text_input(label: str, placeholder: str = "", size: float = 1.0) -> str:
-    """Create a text input component with consistent ID based on label."""
-    service = PreswaldService.get_instance()
+def text_input(
+    label: str,
+    placeholder: str = "",
+    default: str = "",
+    size: float = 1.0,
+) -> str:
+    """Create a text input component.
 
-    # Create a consistent ID based on the label
+    Args:
+        label: Label text shown above the input
+        placeholder: Placeholder text shown when input is empty
+        default: Initial value for the input
+        size: Component width (1.0 = full width)
+
+    Returns:
+        str: Current value of the input
+    """
+    service = PreswaldService.get_instance()
     component_id = generate_id_by_label("text_input", label)
 
     # Get current state or use default
     current_value = service.get_component_state(component_id)
     if current_value is None:
-        current_value = ""
+        current_value = default
 
-    logger.debug(
-        f"Creating text input component with id {component_id}, label: {label}"
-    )
     component = {
         "type": "text_input",
         "id": component_id,
@@ -638,7 +803,7 @@ def text_input(label: str, placeholder: str = "", size: float = 1.0) -> str:
         "value": current_value,
         "size": size,
     }
-    logger.debug(f"Created component: {component}")
+
     service.append_component(component)
     return current_value
 
@@ -769,90 +934,90 @@ def generate_id_by_label(prefix: str, label: str) -> str:
     return f"{prefix}-{hashed}"
 
 
-async def render_and_send_fastplotlib(
-    fig: fplt.Figure,
-    component_id: str,
-    label: str,
-    size: float,
-    client_id: str,
-    data_hash: str,
-) -> Optional[str]:
-    """
-    Asynchronously renders a Fastplotlib figure to an offscreen canvas, encodes it as a PNG,
-    and streams the resulting image data via WebSocket to the connected frontend client.
-
-    This helper function handles rendering logic, alpha-blending, and ensures robust error
-    handling. It updates the component state after successfully sending the image data.
-
-    Args:
-        fig (fplt.Figure): The fully configured Fastplotlib figure instance to render.
-        component_id (str): Unique identifier for the component instance receiving this image.
-        label (str): Human-readable label describing the component (for logging/debugging).
-        size (float): Relative size of the component in the UI layout (0.0-1.0).
-        client_id (str): WebSocket client identifier to route the rendered image correctly.
-        data_hash (str): SHA-256 hash representing the figure state, used for cache invalidation.
-
-    Returns:
-        str: Returns "Render failed" if framebuffer blending fails, otherwise None.
-
-    Raises:
-        Logs and handles any exceptions internally without raising further.
-    """
-    service = PreswaldService.get_instance()
-
-    fig.show()  # must call even in offscreen mode to initialize GPU resources
-
-    # manually render the scene for all subplots
-    for subplot in fig:
-        subplot.viewport.render(subplot.scene, subplot.camera)
-
-    # read from the framebuffer
-    try:
-        fig.canvas.request_draw()
-        raw_img = np.asarray(fig.renderer.target.draw())
-
-        if raw_img.ndim != 3 or raw_img.shape[2] != 4:
-            raise ValueError(f"Unexpected image shape: {raw_img.shape}")
-
-        # handle alpha blending
-        alpha = raw_img[..., 3:4] / 255.0
-        rgb = (raw_img[..., :3] * alpha + (1 - alpha) * 255).astype(np.uint8)
-
-    except Exception as e:
-        logger.error(f"Framebuffer blending failed for {component_id}: {e}")
-        return "Render failed"
-
-    # encode image to PNG
-    img_buf = io.BytesIO()
-    Image.fromarray(rgb).save(img_buf, format="PNG")
-    png_bytes = img_buf.getvalue()
-
-    # handle websocket communication
-    client_websocket = service.websocket_connections.get(client_id)
-    if client_websocket:
-        packed_msg = msgpack.packb(
-            {
-                "type": "image_update",
-                "component_id": component_id,
-                "format": "png",
-                "label": label,
-                "size": size,
-                "data": png_bytes,
-            },
-            use_bin_type=True,
-        )
-
-        try:
-            await client_websocket.send_bytes(packed_msg)
-            await service.handle_client_message(
-                client_id,
-                {
-                    "type": "component_update",
-                    "states": {f"{component_id}_img_hash": data_hash},
-                },
-            )
-            logger.debug(f"✅ Sent {component_id} image to client {client_id}")
-        except Exception as e:
-            logger.error(f"WebSocket send failed for {component_id}: {e}")
-    else:
-        logger.warning(f"No active WebSocket found for client ID: {client_id}")
+# async def render_and_send_fastplotlib(
+#     fig: "fplt.Figure",
+#     component_id: str,
+#     label: str,
+#     size: float,
+#     client_id: str,
+#     data_hash: str,
+# ) -> Optional[str]:
+#     """
+#     Asynchronously renders a Fastplotlib figure to an offscreen canvas, encodes it as a PNG,
+#     and streams the resulting image data via WebSocket to the connected frontend client.
+#
+#     This helper function handles rendering logic, alpha-blending, and ensures robust error
+#     handling. It updates the component state after successfully sending the image data.
+#
+#     Args:
+#         fig (fplt.Figure): The fully configured Fastplotlib figure instance to render.
+#         component_id (str): Unique identifier for the component instance receiving this image.
+#         label (str): Human-readable label describing the component (for logging/debugging).
+#         size (float): Relative size of the component in the UI layout (0.0-1.0).
+#         client_id (str): WebSocket client identifier to route the rendered image correctly.
+#         data_hash (str): SHA-256 hash representing the figure state, used for cache invalidation.
+#
+#     Returns:
+#         str: Returns "Render failed" if framebuffer blending fails, otherwise None.
+#
+#     Raises:
+#         Logs and handles any exceptions internally without raising further.
+#     """
+#     service = PreswaldService.get_instance()
+#
+#     fig.show()  # must call even in offscreen mode to initialize GPU resources
+#
+#     # manually render the scene for all subplots
+#     for subplot in fig:
+#         subplot.viewport.render(subplot.scene, subplot.camera)
+#
+#     # read from the framebuffer
+#     try:
+#         fig.canvas.request_draw()
+#         raw_img = np.asarray(fig.renderer.target.draw())
+#
+#         if raw_img.ndim != 3 or raw_img.shape[2] != 4:
+#             raise ValueError(f"Unexpected image shape: {raw_img.shape}")
+#
+#         # handle alpha blending
+#         alpha = raw_img[..., 3:4] / 255.0
+#         rgb = (raw_img[..., :3] * alpha + (1 - alpha) * 255).astype(np.uint8)
+#
+#     except Exception as e:
+#         logger.error(f"Framebuffer blending failed for {component_id}: {e}")
+#         return "Render failed"
+#
+#     # encode image to PNG
+#     img_buf = io.BytesIO()
+#     Image.fromarray(rgb).save(img_buf, format="PNG")
+#     png_bytes = img_buf.getvalue()
+#
+#     # handle websocket communication
+#     client_websocket = service.websocket_connections.get(client_id)
+#     if client_websocket:
+#         packed_msg = msgpack.packb(
+#             {
+#                 "type": "image_update",
+#                 "component_id": component_id,
+#                 "format": "png",
+#                 "label": label,
+#                 "size": size,
+#                 "data": png_bytes,
+#             },
+#             use_bin_type=True,
+#         )
+#
+#         try:
+#             await client_websocket.send_bytes(packed_msg)
+#             await service.handle_client_message(
+#                 client_id,
+#                 {
+#                     "type": "component_update",
+#                     "states": {f"{component_id}_img_hash": data_hash},
+#                 },
+#             )
+#             logger.debug(f"✅ Sent {component_id} image to client {client_id}")
+#         except Exception as e:
+#             logger.error(f"WebSocket send failed for {component_id}: {e}")
+#     else:
+#         logger.warning(f"No active WebSocket found for client ID: {client_id}")

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,6 @@ CORE_DEPENDENCIES = [
     "Requests>=2.31.0",  # NOTE: maybe need to make this server only as well?
     "setuptools>=69.5.1",
     "tomli>=2.0.1",  # TODO: standardize alongside toml/tomllib
-    "scipy>=1.15.2"
 ]
 
 # Define additional dependencies for development

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ CORE_DEPENDENCIES = [
     "Requests>=2.31.0",  # NOTE: maybe need to make this server only as well?
     "setuptools>=69.5.1",
     "tomli>=2.0.1",  # TODO: standardize alongside toml/tomllib
+    "scipy>=1.15.2"
 ]
 
 # Define additional dependencies for development


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to contribute to the project
title: ''
labels: ''
assignees: ''
---


**Description of Changes**
API keys for the chat component can now be loaded from a project's `secrets.toml` file. Keys that are entered during a session are not saved and will remain only in the sessionStorage until the app is closed. 

**Type of Change**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] New example
- [ ] Test improvement

**Testing**
Code has been tested against the currently present chat example in the Iris example project.

![Screenshot (812)](https://github.com/user-attachments/assets/d085e5b7-84d5-4ce3-a5c2-c54494766709)
![Screenshot (813)](https://github.com/user-attachments/assets/9903c72d-720d-4690-9f0e-c818d651c6e7)


https://github.com/user-attachments/assets/b6110053-e4ae-4556-a971-811786dce517

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run my code against examples and ensured no errors
- [x] Any dependent changes have been merged and published in downstream modules