### PR TITLE
Remove need to call connect explicitly

### DIFF
--- a/examples/earthquakes/hello.py
+++ b/examples/earthquakes/hello.py
@@ -1,16 +1,11 @@
 import pandas as pd
 import plotly.express as px
 
-from preswald import connect, get_df, plotly, slider, table, text
+from preswald import get_df, plotly, slider, table, text
 
 
 # Title
 text("# Earthquake Analytics Dashboard 🌍")
-
-# Load and connect data
-connect()
-
-# ---
 
 # Clickhouse section
 

--- a/examples/fires/hello.py
+++ b/examples/fires/hello.py
@@ -1,14 +1,11 @@
 import pandas as pd
 import plotly.express as px
 
-from preswald import connect, get_df, plotly, text
+from preswald import get_df, plotly, text
 
 
 # Display the dashboard title
 text("# Fire Incident Analytics Dashboard 🔥")
-
-# Connect to the data
-connect()
 
 # Load and preprocess the data
 data = get_df("csv")

--- a/examples/iris/hello.py
+++ b/examples/iris/hello.py
@@ -5,7 +5,6 @@ import plotly.express as px
 
 from preswald import (
     chat,
-    connect,
     # fastplotlib,
     get_df,
     plotly,
@@ -28,7 +27,6 @@ text(
 )
 
 # Load the CSV
-connect()  # Load in all sources, which by default is the iris_csv
 df = get_df("iris_csv")
 
 # 1. Scatter plot - Sepal Length vs Sepal Width

--- a/examples/user_event/hello.py
+++ b/examples/user_event/hello.py
@@ -1,30 +1,30 @@
-from preswald import text, plotly, connect, get_df, table
-import pandas as pd
 import plotly.express as px
+
+from preswald import get_df, plotly, table, text
+
 
 text("# Welcome to Preswald!")
 text("This is your first app. 🎉")
 
 # Load the JSON source defined as "user_events" in preswald.toml
-connect()  # This loads all data sources, including our nested JSON source.
-df = get_df('user_events')
+df = get_df("user_events")
 
 # Create a scatter plot using the flattened data.
 # Assuming the JSON file has been flattened to include "user" and "details.clicks"
 fig = px.scatter(
     df,
-    x='user',
-    y='details.clicks',
-    text='user',
-    title='User Events: Clicks per User',
-    labels={'user': 'User', 'details.clicks': 'Clicks'}
+    x="user",
+    y="details.clicks",
+    text="user",
+    title="User Events: Clicks per User",
+    labels={"user": "User", "details.clicks": "Clicks"},
 )
 
 # Add labels for each point
-fig.update_traces(textposition='top center', marker=dict(size=12, color='lightblue'))
+fig.update_traces(textposition="top center", marker={"size": 12, "color": "lightblue"})
 
 # Style the plot
-fig.update_layout(template='plotly_white')
+fig.update_layout(template="plotly_white")
 
 # Display the plot
 plotly(fig)

--- a/preswald/browser/virtual_service.py
+++ b/preswald/browser/virtual_service.py
@@ -5,7 +5,7 @@ Browser compatibility layer for Preswald in Pyodide environments
 import asyncio
 import logging
 import sys
-from typing import Any, Dict, Optional
+from typing import Any
 
 from preswald.engine.base_service import BasePreswaldService
 from preswald.engine.utils import RenderBuffer
@@ -37,7 +37,7 @@ class VirtualWebSocket:
         )
         console.log(f"[Communication] is browser mode: {self.is_browser_mode}")
 
-    async def send_json(self, data: Dict[str, Any]):
+    async def send_json(self, data: dict[str, Any]):
         """Send JSON data to JavaScript frontend"""
         if not self.is_connected:
             logger.error(f"Cannot send message, connection closed for {self.client_id}")
@@ -185,11 +185,14 @@ class VirtualPreswaldService(BasePreswaldService):
                 if logger.isEnabledFor(logging.DEBUG):
                     logger.debug(f"Handling JS message from {client_id}: {message}")
 
-                asyncio.create_task(self.handle_client_message(client_id, message))   # noqa: RUF006
+                asyncio.create_task(self.handle_client_message(client_id, message))  # noqa: RUF006
                 return True
             except Exception:
                 import traceback
-                logger.error("Error in handle_message_from_js: %s", traceback.format_exc())
+
+                logger.error(
+                    "Error in handle_message_from_js: %s", traceback.format_exc()
+                )
                 return False
 
         # Export the function to JavaScript

--- a/preswald/engine/managers/data.py
+++ b/preswald/engine/managers/data.py
@@ -50,6 +50,7 @@ def load_json_source(config: dict[str, Any]) -> pd.DataFrame:
         ) from e
 
 
+# Database Configs ############################################################
 @dataclass
 class ClickhouseConfig:
     """Configuration for Clickhouse connection"""
@@ -72,6 +73,7 @@ class PostgresConfig:
     password: str
 
 
+# File Configs ################################################################
 @dataclass
 class CSVConfig:
     path: str
@@ -85,6 +87,13 @@ class JSONConfig:
 
 
 @dataclass
+class ParquetConfig:
+    path: str
+    columns: list[str] | None
+
+
+# API Configs #################################################################
+@dataclass
 class APIConfig:
     """Configuration for API connection"""
 
@@ -96,6 +105,7 @@ class APIConfig:
     pagination: dict[str, Any] | None = None
 
 
+# S3 Configs ##################################################################
 @dataclass
 class S3CSVConfig:
     s3_endpoint: str
@@ -105,12 +115,6 @@ class S3CSVConfig:
     path: str
     s3_use_ssl: bool = False
     s3_url_style: str = "path"
-
-
-@dataclass
-class ParquetConfig:
-    path: str
-    columns: list[str] | None
 
 
 class DataSource:
@@ -418,6 +422,21 @@ class DataManager:
 
     def connect(self):  # noqa: C901
         """Initialize all data sources from config"""
+        # Useful debugging query - Log final DuckDB state
+        # tables_df = self.duckdb_conn.execute("""
+        #     SELECT
+        #         table_name,
+        #         column_count,
+        #         estimated_size as size_b
+        #     FROM duckdb_tables()
+        # """).df()
+
+        # logger.info(f"Current DuckDB state - {len(tables_df)} tables:")
+        # for _, row in tables_df.iterrows():
+        #     logger.info(
+        #         f"Table: {row['table_name']}, Columns: {row['column_count']}, Estimated Size: {row['size_b']:.2f}B"
+        #     )
+
         config = self._load_sources()
         sources_to_remove = set(self.sources.keys()) - set(config.keys())
 

--- a/preswald/engine/managers/data.py
+++ b/preswald/engine/managers/data.py
@@ -1,10 +1,9 @@
+import json
 import logging
 import os
 import uuid
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
-import pandas as pd
-import json
+from typing import Any
 
 import duckdb
 import pandas as pd
@@ -15,26 +14,29 @@ from requests.auth import HTTPBasicAuth
 
 logger = logging.getLogger(__name__)
 
-def load_json_source(config: Dict[str, Any]) -> pd.DataFrame:
+
+def load_json_source(config: dict[str, Any]) -> pd.DataFrame:
     path = config["path"]
     record_path = config.get("record_path")
     flatten = config.get("flatten", True)
 
     # Open and load the JSON file
     try:
-        with open(path, "r", encoding="utf-8") as f:
+        with open(path, encoding="utf-8") as f:
             data = json.load(f)
     except json.JSONDecodeError as e:
-        raise ValueError(f"Malformed JSON in file '{path}': {e}")
+        raise ValueError(f"Malformed JSON in file '{path}': {e}") from e
     except Exception as e:
-        raise ValueError(f"Error reading JSON file '{path}': {e}")
+        raise ValueError(f"Error reading JSON file '{path}': {e}") from e
 
     # Apply record_path if provided
     if record_path:
         try:
             data = data[record_path]
         except (KeyError, TypeError) as e:
-            raise ValueError(f"Invalid record_path '{record_path}' for JSON file '{path}': {e}")
+            raise ValueError(
+                f"Invalid record_path '{record_path}' for JSON file '{path}': {e}"
+            ) from e
 
     # Normalize or convert data if "flatten"
     try:
@@ -43,7 +45,10 @@ def load_json_source(config: Dict[str, Any]) -> pd.DataFrame:
         else:
             return pd.DataFrame(data)
     except Exception as e:
-        raise ValueError(f"Error converting JSON data from file '{path}' to DataFrame: {e}")
+        raise ValueError(
+            f"Error converting JSON data from file '{path}' to DataFrame: {e}"
+        ) from e
+
 
 @dataclass
 class ClickhouseConfig:
@@ -75,7 +80,7 @@ class CSVConfig:
 @dataclass
 class JSONConfig:
     path: str
-    record_path: Optional[str] = None
+    record_path: str | None = None
     flatten: bool = True
 
 
@@ -85,10 +90,10 @@ class APIConfig:
 
     url: str  #  URL of the API
     method: str = "GET"  # HTTP method (GET, POST, etc.)
-    headers: Optional[Dict[str, str]] = None
-    params: Optional[Dict[str, Any]] = None  # Query parameters
-    auth: Optional[Dict[str, str]] = None  # Authentication (API key, Bearer token)
-    pagination: Optional[Dict[str, Any]] = None
+    headers: dict[str, str] | None = None
+    params: dict[str, Any] | None = None  # Query parameters
+    auth: dict[str, str] | None = None  # Authentication (API key, Bearer token)
+    pagination: dict[str, Any] | None = None
 
 
 @dataclass
@@ -105,7 +110,7 @@ class S3CSVConfig:
 @dataclass
 class ParquetConfig:
     path: str
-    columns: Optional[list[str]]
+    columns: list[str] | None
 
 
 class DataSource:
@@ -184,10 +189,13 @@ class CSVSource(DataSource):
         """Get entire CSV as a DataFrame"""
         return self._duckdb.execute(f"SELECT * FROM {self._table_name}").df()
 
+
 class JSONSource(DataSource):
-    def __init__(self, name: str, config: JSONConfig, duckdb_conn: duckdb.DuckDBPyConnection):
+    def __init__(
+        self, name: str, config: JSONConfig, duckdb_conn: duckdb.DuckDBPyConnection
+    ):
         super().__init__(name, duckdb_conn)
-        df = load_json_source(config.__dict__)
+        load_json_source(config.__dict__)
         self._table_name = f"json_{name}_{uuid.uuid4().hex[:8]}"
         self._duckdb.execute(f"CREATE TABLE {self._table_name} AS SELECT * FROM df")
 
@@ -196,6 +204,7 @@ class JSONSource(DataSource):
 
     def to_df(self) -> pd.DataFrame:
         return self._duckdb.execute(f"SELECT * FROM {self._table_name}").df()
+
 
 class PostgresSource(DataSource):
     def __init__(
@@ -400,10 +409,10 @@ class ParquetSource(DataSource):
 
 
 class DataManager:
-    def __init__(self, preswald_path: str, secrets_path: Optional[str] = None):
+    def __init__(self, preswald_path: str, secrets_path: str | None = None):
         self.preswald_path = preswald_path
         self.secrets_path = secrets_path
-        self.sources: Dict[str, DataSource] = {}
+        self.sources: dict[str, DataSource] = {}
         self.duckdb_conn = duckdb.connect(":memory:")
 
     def connect(self):
@@ -491,9 +500,7 @@ class DataManager:
             raise ValueError(f"Unknown source: {source_name}")
         return self.sources[source_name].query(sql)
 
-    def get_df(
-        self, source_name: str, table_name: Optional[str] = None
-    ) -> pd.DataFrame:
+    def get_df(self, source_name: str, table_name: str | None = None) -> pd.DataFrame:
         """Get entire source as DataFrame"""
         if source_name not in self.sources:
             raise ValueError(f"Unknown source: {source_name}")
@@ -505,7 +512,7 @@ class DataManager:
             return source.to_df(table_name)
         return source.to_df()
 
-    def _load_sources(self) -> Dict[str, Any]:
+    def _load_sources(self) -> dict[str, Any]:
         """Load data sources from preswald config and secrets files."""
         try:
             if not os.path.exists(self.preswald_path):

--- a/preswald/engine/server_service.py
+++ b/preswald/engine/server_service.py
@@ -28,7 +28,7 @@ class ServerPreswaldService(BasePreswaldService):
 
         # TODO: deprecated
         # Connection management
-        self._connections: Dict[str, Any] = {}
+        self._connections: dict[str, Any] = {}
 
         # Branding management
         self.branding_manager = None  # set during server creation

--- a/preswald/templates/hello.py.template
+++ b/preswald/templates/hello.py.template
@@ -6,7 +6,6 @@ text("# Welcome to Preswald!")
 text("This is your first app. 🎉")
 
 # Load the CSV
-connect() # load in all sources, which by default is the sample_csv
 df = get_df('sample_csv')
 
 # Create a scatter plot

--- a/preswald/tutorial/hello.py
+++ b/preswald/tutorial/hello.py
@@ -9,7 +9,6 @@ from preswald import (
     button,
     chat,
     checkbox,
-    connect,
     get_df,
     image,
     matplotlib,
@@ -72,7 +71,6 @@ def load_data():
     text("## 2. Viewing Data with `table()`")
     text("Let's load a sample dataset and display it using the `table()` component.")
 
-    connect()
     df = get_df("sample_csv")
     table(df, limit=10)  # Display first 10 rows
 
@@ -260,7 +258,6 @@ The `workflow_dag()` function renders a Directed Acyclic Graph (DAG) to visualiz
 
     @demo_workflow.atom()
     def demo_load_data():
-        connect()
         return get_df("sample_csv")
 
     @demo_workflow.atom(dependencies=["demo_load_data"])
@@ -286,7 +283,6 @@ from preswald import workflow_dag, Workflow
 workflow = Workflow()
 @workflow.atom()
 def load_data():
-    connect()
     return get_df("sample_csv")
 @workflow.atom(dependencies=['load_data'])
 def clean_data(load_data):


### PR DESCRIPTION
**Related Issue**
Fixes duplication happening when `connect()` is called multiple times (as it is due to script re-renders)

**Description of Changes**
Ensure `connect` is idempotent by creating a cache of source configs in `preswald/engine/managers/data.py`
Call `connect()` in `runner.py` in `run_script` so user doesn't have to include it in their script.

**Type of Change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] New example
- [ ] Test improvement

**Testing**
Ran local and auto-test on the examples.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run my code against examples and ensured no errors
- [x] Any dependent changes have been merged and published in downstream modules