### PR TITLE
Fix sidebar logo alignment

### DIFF
--- a/frontend/src/components.css
+++ b/frontend/src/components.css
@@ -61,7 +61,7 @@
 }
 
 .sidebar-desktop-collapsed .sidebar-logo {
-  @apply h-8 w-auto;
+  @apply h-8 w-8 rounded-sm ml-3;
 }
 
 .sidebar-title {

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { PanelLeft, PanelLeftClose } from 'lucide-react';
-import { Link, useLocation } from 'react-router-dom';
+
 import * as React from 'react';
 import { useEffect } from 'react';
+import { Link, useLocation } from 'react-router-dom';
 
 import TableOfContents from '@/components/TableOfContents';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
@@ -27,7 +28,7 @@ const Sidebar = ({
         <div className="sidebar-nav">
           {!isMobile && (
             <div className="sidebar-header">
-              <div className="flex items-center">
+              <div className="flex items-center justify-center">
                 <img src={branding?.logo} alt={branding?.name} className="sidebar-logo" />
                 {!isCollapsed && <span className="sidebar-title">{branding?.name}</span>}
               </div>


### PR DESCRIPTION
This PR fixes the alignment of the sidebar logo when in collapsed mode. Along with that, rounded edges have been added for the logo for smoother appearance.

**Related Issue**
Fixes #41 

**Description of Changes**
For aligning it correctly, left margin has been added to sidebar-logo class. For rounded edges, border-radius is also added.

**Type of Change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] New example
- [ ] Test improvement

**Testing**
Please describe the tests that you ran to verify your changes. Include screenshots/videos.

Before
![Before alignment](https://github.com/user-attachments/assets/730d51f0-b0e2-4810-bc40-17b56a9647d5)

After
![After alignment and rounded edges](https://github.com/user-attachments/assets/6cd8d845-db56-435a-a49f-6ef8595432f8)



**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run my code against examples and ensured no errors
- [ ] Any dependent changes have been merged and published in downstream modules