### PR TITLE
Feature: Added Support For Vega-Lite Based Components

### DIFF
--- a/examples/iris/hello.py
+++ b/examples/iris/hello.py
@@ -7,6 +7,7 @@ from preswald import (
     chat,
     # fastplotlib,
     get_df,
+    mosaic,
     plotly,
     sidebar,
     table,
@@ -43,6 +44,26 @@ fig1 = px.scatter(
 )
 fig1.update_layout(template="plotly_white")
 plotly(fig1)
+
+
+text("# Mosaic Example")
+
+mosaic(
+    label="Iris Mosaic Plot",
+    spec={
+        "$schema": "https://vega.github.io/schema/vega-lite/v6.json",
+        "description": "A scatterplot showing horsepower and miles per gallons for various cars.",
+        "data": {
+            "url": "https://raw.githubusercontent.com/vega/vega-datasets/refs/heads/main/data/cars.json"
+        },
+        "mark": "point",
+        "encoding": {
+            "x": {"field": "Horsepower", "type": "quantitative"},
+            "y": {"field": "Miles_per_Gallon", "type": "quantitative"},
+        },
+    },
+)
+
 
 # 2. Histogram of Sepal Length
 text(

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -52,7 +52,10 @@
         "remark-gfm": "^4.0.0",
         "remark-slug": "^7.0.1",
         "tailwind-merge": "^2.6.0",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "vega": "^6.1.2",
+        "vega-embed": "^7.0.2",
+        "vega-lite": "^6.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.19.0",
@@ -3325,9 +3328,9 @@
       }
     },
     "node_modules/@types/geojson": {
-      "version": "7946.0.15",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.15.tgz",
-      "integrity": "sha512-9oSxFzDCT2Rj6DfcHF8G++jxBKS7mBqXl5xrRW+Kbvjry6Uduya2iiwqHPhVXpasAVMBYKkEPGgKhd3+/HZ6xA==",
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
     "node_modules/@types/geojson-vt": {
@@ -4550,6 +4553,78 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
@@ -4905,6 +4980,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-dispatch": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
@@ -4922,6 +5009,52 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/d3-ease": {
@@ -5028,6 +5161,59 @@
       "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.7.tgz",
       "integrity": "sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale/node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale/node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/d3-selection": {
       "version": "3.0.0",
@@ -5268,6 +5454,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
+      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/delayed-stream": {
@@ -6254,6 +6449,12 @@
         "is-string-blank": "^1.0.1"
       }
     },
+    "node_modules/fast-json-patch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -6576,6 +6777,15 @@
       "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
       "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==",
       "license": "ISC"
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
     },
     "node_modules/get-canvas-context": {
       "version": "1.0.2",
@@ -7489,6 +7699,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-alphabetical": {
@@ -11683,6 +11902,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -11791,6 +12019,12 @@
       "resolved": "https://registry.npmjs.org/right-now/-/right-now-1.0.0.tgz",
       "integrity": "sha512-DA8+YS+sMIVpbsuKgy+Z67L9Lxb1p05mNxRpDPNksPDEFir4vmBlUtuN9jkTGn9YMMdlBuK7XQgFiz6ws+yhSg==",
       "license": "MIT"
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+      "license": "Unlicense"
     },
     "node_modules/rollup": {
       "version": "4.29.1",
@@ -13438,6 +13672,795 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/vega": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-6.1.2.tgz",
+      "integrity": "sha512-d5GT7wRoRnK+bsQWgauOHyPFY4td52PTuX5IzMXr9PXHkz2OKXpVti7LeK5evAoyhNxVenkT1ptpRQKU2MRJdw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "vega-crossfilter": "~5.0.0",
+        "vega-dataflow": "~6.0.0",
+        "vega-encode": "~5.0.0",
+        "vega-event-selector": "~4.0.0",
+        "vega-expression": "~6.0.0",
+        "vega-force": "~5.0.0",
+        "vega-format": "~2.0.0",
+        "vega-functions": "~6.0.0",
+        "vega-geo": "~5.0.0",
+        "vega-hierarchy": "~5.0.0",
+        "vega-label": "~2.0.0",
+        "vega-loader": "~5.0.0",
+        "vega-parser": "~7.0.0",
+        "vega-projection": "~2.0.0",
+        "vega-regression": "~2.0.0",
+        "vega-runtime": "~7.0.0",
+        "vega-scale": "~8.0.0",
+        "vega-scenegraph": "~5.0.0",
+        "vega-statistics": "~2.0.0",
+        "vega-time": "~3.0.0",
+        "vega-transforms": "~5.0.0",
+        "vega-typings": "~2.0.0",
+        "vega-util": "~2.0.0",
+        "vega-view": "~6.0.0",
+        "vega-view-transforms": "~5.0.0",
+        "vega-voronoi": "~5.0.0",
+        "vega-wordcloud": "~5.0.0"
+      },
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
+      }
+    },
+    "node_modules/vega-canvas": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-2.0.0.tgz",
+      "integrity": "sha512-9x+4TTw/USYST5nx4yN272sy9WcqSRjAR0tkQYZJ4cQIeon7uVsnohvoPQK1JZu7K1QXGUqzj08z0u/UegBVMA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/vega-crossfilter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-5.0.0.tgz",
+      "integrity": "sha512-9PnDXpoLY4rWBubTjtAxEmEdSLq4pg1OyyucugnGNX6HsaAuF5fXYmXdpe4UB4SMMHMnWM3ZBA2wkkycct11sQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "vega-dataflow": "^6.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "node_modules/vega-crossfilter/node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vega-dataflow": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-6.0.0.tgz",
+      "integrity": "sha512-/6Cl06lqTPDiGwwRgRJ6osAy/qwgeelwK4+tZ4QS/aNJhoEAJU5xPXuWl6U0trabUT2Pe0+Qpo1+/u0oAOmmCg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "vega-format": "^2.0.0",
+        "vega-loader": "^5.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "node_modules/vega-embed": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/vega-embed/-/vega-embed-7.0.2.tgz",
+      "integrity": "sha512-ZHQPWSs9mUTGJPZ5yQVhHV+OLDCoTIjR//De93vG6igZX1MQCVo03ePWlfWCUAnPV1IsKfeJLqA3K/Qd11bAFQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "fast-json-patch": "^3.1.1",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "semver": "^7.7.1",
+        "tslib": "^2.8.1",
+        "vega-interpreter": "^2.0.0",
+        "vega-schema-url-parser": "^3.0.2",
+        "vega-themes": "3.0.0",
+        "vega-tooltip": "1.0.0"
+      },
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
+      },
+      "peerDependencies": {
+        "vega": "*",
+        "vega-lite": "*"
+      }
+    },
+    "node_modules/vega-embed/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/vega-embed/node_modules/vega-interpreter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-interpreter/-/vega-interpreter-2.0.0.tgz",
+      "integrity": "sha512-ZjA7AC+xjfi4k9vgA49N5F/bS4fzf9E1KC0ljey4uMgHbmtKR53BWyOOzxHk+btfS9bEJ5gUvuoZzfqG3wIWEg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "vega-util": "^2.0.0"
+      }
+    },
+    "node_modules/vega-embed/node_modules/vega-schema-url-parser": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/vega-schema-url-parser/-/vega-schema-url-parser-3.0.2.tgz",
+      "integrity": "sha512-xAnR7KAvNPYewI3O0l5QGdT8Tv0+GCZQjqfP39cW/hbe/b3aYMAQ39vm8O2wfXUHzm04xTe7nolcsx8WQNVLRQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/vega-embed/node_modules/vega-tooltip": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vega-tooltip/-/vega-tooltip-1.0.0.tgz",
+      "integrity": "sha512-P1R0JP29v0qnTuwzCQ0SPJlkjAzr6qeyj+H4VgUFSykHmHc1OBxda//XBaFDl/bZgIscEMvjKSjZpXd84x3aZQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "vega-util": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
+      }
+    },
+    "node_modules/vega-encode": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-5.0.0.tgz",
+      "integrity": "sha512-3YdnCGDMNppicdzyaawP1fYYyJhMUMREwgQmQvF//NFRMY3bzI59Rjhq4v+tIMXXSvnTztJ1Chm9eSvZGiNs+g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "d3-interpolate": "^3.0.1",
+        "vega-dataflow": "^6.0.0",
+        "vega-scale": "^8.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "node_modules/vega-encode/node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vega-event-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-4.0.0.tgz",
+      "integrity": "sha512-CcWF4m4KL/al1Oa5qSzZ5R776q8lRxCj3IafCHs5xipoEHrkgu1BWa7F/IH5HrDNXeIDnqOpSV1pFsAWRak4gQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/vega-expression": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-6.0.0.tgz",
+      "integrity": "sha512-aw6hGpTSiakAe5KqCsnpXNsBgN823IMq84x2Gg1pJj+H6zxlEfN4FCibPAC0PYWOmSvCRUoXMr7b/wWiwsiPIg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/estree": "^1.0.6",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "node_modules/vega-force": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-5.0.0.tgz",
+      "integrity": "sha512-j3HNCrngjuFvOmBl2gg2NNgDys5q6i+v6pliIt9grSAcgzStNNuxcVp+OjNeWP4NSa0Hc7efEGmYvmBqTP/HpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-force": "^3.0.0",
+        "vega-dataflow": "^6.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "node_modules/vega-force/node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vega-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-2.0.0.tgz",
+      "integrity": "sha512-RrMI/HedVEb4PDFyiNjzbJtOLt/H7aan1Fs3sQQamOdSAj5gcq6r9IavzKy7dC4XaovEjdStJL6JSAfTW53CiQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "d3-format": "^3.1.0",
+        "d3-time-format": "^4.1.0",
+        "vega-time": "^3.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "node_modules/vega-format/node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vega-format/node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vega-format/node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vega-functions": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-6.0.0.tgz",
+      "integrity": "sha512-1Qy7VOUIa3GzbfLXYYpTDPQMyJVV27a7U8xCqXtMPozXQo4cKQRb/OKAqMk7A/0eCTs3E08pc41kFa/tYSOIag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "d3-color": "^3.1.0",
+        "d3-geo": "^3.1.1",
+        "vega-dataflow": "^6.0.0",
+        "vega-expression": "^6.0.0",
+        "vega-scale": "^8.0.0",
+        "vega-scenegraph": "^5.0.0",
+        "vega-selections": "^6.0.0",
+        "vega-statistics": "^2.0.0",
+        "vega-time": "^3.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "node_modules/vega-functions/node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vega-functions/node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vega-geo": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-5.0.0.tgz",
+      "integrity": "sha512-cr7Tjktgq0cuYwqhz5Mak6tv7BeaRBz1HaojNLJxJzQtNw1oBdT8gXxSYN1PA61OExHP2mG8GZRF+XdjbnN3LQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "d3-color": "^3.1.0",
+        "d3-geo": "^3.1.1",
+        "vega-canvas": "^2.0.0",
+        "vega-dataflow": "^6.0.0",
+        "vega-projection": "^2.0.0",
+        "vega-statistics": "^2.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "node_modules/vega-geo/node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vega-geo/node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vega-hierarchy": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-5.0.0.tgz",
+      "integrity": "sha512-W2nVICp5946eG5zf5jenHo4Q+LBcYmDQjFt7/7HyRzvZT8IIdhBEuotb2MwmgJ9GeOsmt/DRb53DNZbXMSB9ww==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-hierarchy": "^3.1.2",
+        "vega-dataflow": "^6.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "node_modules/vega-hierarchy/node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vega-label": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-2.0.0.tgz",
+      "integrity": "sha512-e+JIojHNiEcI/4jFoOLhtocbqoQzJqurZwyP3lFgV7nJOQPOZSZYiEUOUhbhYuMgnhz0HDBe3GDqSAeo1yUhfw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "vega-canvas": "^2.0.0",
+        "vega-dataflow": "^6.0.0",
+        "vega-scenegraph": "^5.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "node_modules/vega-lite": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-6.1.0.tgz",
+      "integrity": "sha512-SgL/s0Ddoq2Do0GFd9pOMtJmWW1YOjht98v/fixnpnWi+7hijWRha1tAziDeQLOBwsv5NmjzrJXpYhedRAbv2A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "json-stringify-pretty-compact": "~4.0.0",
+        "tslib": "~2.8.1",
+        "vega-event-selector": "~4.0.0",
+        "vega-expression": "~6.0.0",
+        "vega-util": "~2.0.0",
+        "yargs": "~17.7.2"
+      },
+      "bin": {
+        "vl2pdf": "bin/vl2pdf",
+        "vl2png": "bin/vl2png",
+        "vl2svg": "bin/vl2svg",
+        "vl2vg": "bin/vl2vg"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
+      },
+      "peerDependencies": {
+        "vega": "^6.0.0"
+      }
+    },
+    "node_modules/vega-loader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-5.0.0.tgz",
+      "integrity": "sha512-THLOtcbL0gQjv3GunKWutUiELdLc74nQOfIWNL/kx2qXtM2kYhE5FcCKQNTA9aZzklY3oN8Bt4siJ22ugO0WyA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-dsv": "^3.0.1",
+        "node-fetch": "^3.3.2",
+        "topojson-client": "^3.1.0",
+        "vega-format": "^2.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "node_modules/vega-parser": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-7.0.0.tgz",
+      "integrity": "sha512-820pladvhez0SQBZ8Yohou0fpWd4Vl+AbekGG0eu+mh2BhjJmIDaNC/5j/5sZ/A+ufHO2GPCAt4DSiM/X2jWqg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "vega-dataflow": "^6.0.0",
+        "vega-event-selector": "^4.0.0",
+        "vega-functions": "^6.0.0",
+        "vega-scale": "^8.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "node_modules/vega-projection": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-2.0.0.tgz",
+      "integrity": "sha512-oeNTNKD5iwDImiSTjNqxGrDGACxVmF+1XWxKgplgHsnoB0k4wtcGm0Lc6cZ0rwC6zyJ/4WRVxjUeOVGKpNCpxA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-geo": "^3.1.1",
+        "d3-geo-projection": "^4.0.0",
+        "vega-scale": "^8.0.0"
+      }
+    },
+    "node_modules/vega-projection/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/vega-projection/node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vega-projection/node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vega-projection/node_modules/d3-geo-projection": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-4.0.0.tgz",
+      "integrity": "sha512-p0bK60CEzph1iqmnxut7d/1kyTmm3UWtPlwdkM31AU+LW+BXazd5zJdoCn7VFxNCHXRngPHRnsNn5uGjLRGndg==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "d3-array": "1 - 3",
+        "d3-geo": "1.12.0 - 3"
+      },
+      "bin": {
+        "geo2svg": "bin/geo2svg.js",
+        "geograticule": "bin/geograticule.js",
+        "geoproject": "bin/geoproject.js",
+        "geoquantize": "bin/geoquantize.js",
+        "geostitch": "bin/geostitch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vega-regression": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-2.0.0.tgz",
+      "integrity": "sha512-0OW2+Pp0VQJXkNxpI+a3b3kUdqJacbmHoOKl0frGYtrJzB4GsebBsdd7N2WSztrzPh5cP3oHaYJeQSHgj9P9xw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "vega-dataflow": "^6.0.0",
+        "vega-statistics": "^2.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "node_modules/vega-regression/node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vega-runtime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-7.0.0.tgz",
+      "integrity": "sha512-bFMqxaYwOYVoXIjI3GCZstgjoXI3lvjtRSKMN3n8ASVGbakiGjtUPRcpueYQqrpGFXR8UoQcGeXtIyyHRC68mw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "vega-dataflow": "^6.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "node_modules/vega-scale": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-8.0.0.tgz",
+      "integrity": "sha512-9jEVbxi7NXVYYF2l+2PB2UcvAX/RxBMzOam7afP+68w2DeGJz43AF/8NGc9tjZZAE5SYTERotxKki31PkAPOFg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.1.0",
+        "vega-time": "^3.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "node_modules/vega-scale/node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vega-scenegraph": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-5.0.0.tgz",
+      "integrity": "sha512-BkE4n+mgMpEcHF2EKo+27Sjso0x/zPqgZjoP5dngjSkeyJqKfyxi93lDEJNylWBJqcyjNEmOrAkQQi3B4RNtKA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "^3.1.0",
+        "d3-shape": "^3.2.0",
+        "vega-canvas": "^2.0.0",
+        "vega-loader": "^5.0.0",
+        "vega-scale": "^8.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "node_modules/vega-scenegraph/node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vega-scenegraph/node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vega-selections": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-6.0.0.tgz",
+      "integrity": "sha512-ig2NHIV+ZWeQJAD3T+cIJ13qM583an7NvHaDkmuOPPIRvtnrO9CbXCqQ84yHhLrJSzxLwO2h8ExSGkoOmzPUaw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "3.2.4",
+        "vega-expression": "^6.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "node_modules/vega-selections/node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vega-statistics": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-2.0.0.tgz",
+      "integrity": "sha512-dGPfDXnBlgXbZF3oxtkb8JfeRXd5TYHx25Z/tIoaa9jWua4Vf/AoW2wwh8J1qmMy8J03/29aowkp1yk4DOPazQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^3.2.4"
+      }
+    },
+    "node_modules/vega-statistics/node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vega-themes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vega-themes/-/vega-themes-3.0.0.tgz",
+      "integrity": "sha512-1iFiI3BNmW9FrsLnDLx0ZKEddsCitRY3XmUAwp6qmp+p+IXyJYc9pfjlVj9E6KXBPfm4cQyU++s0smKNiWzO4g==",
+      "license": "BSD-3-Clause",
+      "funding": {
+        "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
+      },
+      "peerDependencies": {
+        "vega": "*",
+        "vega-lite": "*"
+      }
+    },
+    "node_modules/vega-time": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-3.0.0.tgz",
+      "integrity": "sha512-Ifs95YXaQ6/3NCJ7l9jdda74uovwLodUHFYQqqXPanjUtF9e5juw4/VurbgIPYnB76w4ye6/q19OdlUeUdVQuw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "d3-time": "^3.1.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "node_modules/vega-time/node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vega-time/node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vega-transforms": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-5.0.0.tgz",
+      "integrity": "sha512-a4fo0tlfZFE1C/aV+IpEEl/SAyz9JnVqYCxcEeuQm6byglCz+PnjZmnqFyKFBnmVHDjQ/GP82DkqGBx52Cr0Kg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "vega-dataflow": "^6.0.0",
+        "vega-statistics": "^2.0.0",
+        "vega-time": "^3.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "node_modules/vega-transforms/node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vega-typings": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-2.0.1.tgz",
+      "integrity": "sha512-Jfw2zeAv4rQ8YqfgBae3QauK0T9FUpQ+0q3NNLW24Z6nyjf8H2ucnyLhw6pIqfVytne6VB4WkvazTOgJPuv5vw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/geojson": "7946.0.16",
+        "vega-event-selector": "^4.0.0",
+        "vega-expression": "^6.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "node_modules/vega-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
+      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/vega-view": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-6.0.0.tgz",
+      "integrity": "sha512-Q4bS6eEt+d8N1ZKGg/jueEFboR1CGO8olye7vz3gS/iyg4fPDwMx0sh4pDiX077OPD3UW/0NbplIiHwzQyabEg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^3.2.4",
+        "d3-timer": "^3.0.1",
+        "vega-dataflow": "^6.0.0",
+        "vega-format": "^2.0.0",
+        "vega-functions": "^6.0.0",
+        "vega-runtime": "^7.0.0",
+        "vega-scenegraph": "^5.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "node_modules/vega-view-transforms": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-5.0.0.tgz",
+      "integrity": "sha512-AqQStHIYZtjsm84rx43z6P18DdR4/l20q/mfWXJ2Ifts1T2gPshC24/0xUfGrnwpqM5m3X1HwkJUiyEJxzVQrQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "vega-dataflow": "^6.0.0",
+        "vega-scenegraph": "^5.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "node_modules/vega-view/node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vega-view/node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vega-voronoi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-5.0.0.tgz",
+      "integrity": "sha512-mmsQFo7Aj8WM/QS8Ta79QWxADU3WpvEQ0OIR20WFgY/QLJ+42FEcJkBlaSQQ+DFl2Ci5PdbpZtRFMPJoRokFMw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-delaunay": "^6.0.4",
+        "vega-dataflow": "^6.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
+    "node_modules/vega-wordcloud": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-5.0.0.tgz",
+      "integrity": "sha512-Rm46D1ginGdunWLtsiymllU5RvJTEtpKRaWcc/pABpFiz7QHGGrZ9FhOczxW1o3n89h07gzc9n8xlWYco06Fdw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "vega-canvas": "^2.0.0",
+        "vega-dataflow": "^6.0.0",
+        "vega-scale": "^8.0.0",
+        "vega-statistics": "^2.0.0",
+        "vega-util": "^2.0.0"
+      }
+    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -13902,6 +14925,15 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -13919,6 +14951,74 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,7 +57,10 @@
     "remark-gfm": "^4.0.0",
     "remark-slug": "^7.0.1",
     "tailwind-merge": "^2.6.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "vega": "^6.1.2",
+    "vega-embed": "^7.0.2",
+    "vega-lite": "^6.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.19.0",

--- a/frontend/src/components/DynamicComponents.jsx
+++ b/frontend/src/components/DynamicComponents.jsx
@@ -20,6 +20,7 @@ import FastplotlibWidget from './widgets/FastplotlibWidget';
 import ImageWidget from './widgets/ImageWidget';
 import MarkdownRendererWidget from './widgets/MarkdownRendererWidget';
 import MatplotlibWidget from './widgets/MatplotlibWidget';
+import MosaicWidget from './widgets/MosaicWidget';
 import PlaygroundWidget from './widgets/PlaygroundWidget';
 import ProgressWidget from './widgets/ProgressWidget';
 import SelectboxWidget from './widgets/SelectboxWidget';
@@ -90,6 +91,15 @@ const MemoizedComponent = memo(
           </ButtonWidget>
         );
 
+      case 'mosaic':
+        return (
+          <MosaicWidget
+            {...props}
+            className={component.className}
+            _size={component.size}
+            spec={component.spec}
+          />
+        );
       case 'big_number':
         return (
           <BigNumberWidget

--- a/frontend/src/components/widgets/MosaicWidget.jsx
+++ b/frontend/src/components/widgets/MosaicWidget.jsx
@@ -1,0 +1,27 @@
+import vegaEmbed from 'vega-embed';
+
+import React, { useEffect, useRef } from 'react';
+
+import { Card } from '@/components/ui/card';
+
+import { cn } from '@/lib/utils';
+
+const MosaicWidget = ({ spec, className }) => {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    if (containerRef.current && spec) {
+      vegaEmbed(containerRef.current, spec) // {actions: false} to remove extra options
+        .then((result) => console.log(result))
+        .catch((error) => console.error(error));
+    }
+  }, [spec]);
+
+  return (
+    <Card className={cn('w-full overflow-x-auto', className)}>
+      <div ref={containerRef}></div>;
+    </Card>
+  );
+};
+
+export default MosaicWidget;

--- a/preswald/interfaces/__init__.py
+++ b/preswald/interfaces/__init__.py
@@ -12,6 +12,7 @@ from .components import (
     # fastplotlib,
     image,
     matplotlib,
+    mosaic,
     playground,
     plotly,
     progress,

--- a/preswald/interfaces/components.py
+++ b/preswald/interfaces/components.py
@@ -201,6 +201,36 @@ def chat(source: str, table: str | None = None) -> dict:
     return component
 
 
+def mosaic(
+    label: str,
+    spec: dict,
+    size: float = 1.0,
+) -> str:
+    """Render a Mosaic visualization based on a Vega-Lite-compatible spec"""
+
+    service = PreswaldService.get_instance()
+    component_id = generate_stable_id("mosaic")
+    logger.debug(f"Creating mosaic component with id {component_id}, spec: {spec}")
+    component = {
+        "type": "mosaic",
+        "id": component_id,
+        "label": label,
+        "spec": spec,
+        "size": size,
+    }
+    if service.should_render(component_id, component):
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(f"Created component: {component}")
+        service.append_component(component)
+    else:
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                f"No changes detected. skipping append for component {component}"
+            )
+
+    return f"Mosaic: {label}"
+
+
 def checkbox(label: str, default: bool = False, size: float = 1.0) -> bool:
     """Create a checkbox component with consistent ID based on label."""
     service = PreswaldService.get_instance()


### PR DESCRIPTION
**Related Issue**
Fixes #517

**Description of Changes**
This PR adds support for Vega-Lite based Components .It uses vega-embed to generate a component based on the specs.

**Type of Change**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] New example
- [ ] Test improvement

**Testing**
![mosaic](https://github.com/user-attachments/assets/ee4cbdff-05b0-4590-af20-4646615ca229)

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run my code against examples and ensured no errors
- [x] Any dependent changes have been merged and published in downstream modules


**Features**
- [x] Mosaic widget renders Vega-Lite-style JSON specs.
- [x] Users can pass spec via Python and render rich charts.
- [x] Compatible with browser and server execution.