### PR TITLE
feat(firebase): support Firestore & Realtime DB as Preswald data sources

### DIFF
--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -177,6 +177,39 @@ path = "data/analytics.parquet"
 columns = ["region", "revenue", "score"]
 ```
 
+### Firebase Example: `[data.<your_source_name>]`
+
+Use **Firestore** or **Realtime Database** as a data source.
+
+#### Fields:
+
+- `type`: Must be `"firebase"`.  
+- `credentials_path`: Path to your Firebase service account JSON key.  
+- `project_id`: Your Firebase project ID (for RTDB, include the full instance name, e.g. `my-project-default-rtdb`).  
+- `mode` (optional): `"firestore"` (default) or `"realtime"`.  
+- `collection`: *(Firestore only)* Name of the Firestore collection to load.  
+- `path`: *(Realtime DB only)* Path in your Realtime Database to load.
+
+#### Example Firestore Connection:
+
+```toml
+[data.user_metrics]
+type             = "firebase"
+credentials_path = "secrets/firebase-key.json"
+project_id       = "my-firebase-project"
+collection       = "metrics"
+mode             = "firestore"
+
+#### Example Realtime DB Connection:
+
+```toml
+[data.sensors]
+type             = "firebase"
+credentials_path = "secrets/firebase-key.json"
+project_id       = "my-firebase-project-default-rtdb"
+path             = "/devices/sensors"
+mode             = "realtime"
+
 ---
 
 ## Logging Configuration

--- a/docs/data-sources.mdx
+++ b/docs/data-sources.mdx
@@ -1,0 +1,20 @@
+---
+title: "Data Sources"
+icon: "database"
+description: "List of all built‑in data sources, their modes, and required configuration fields."
+---
+
+## Data Source Compatibility Matrix
+
+| Data Source                      | Modes Supported        | Required Fields                                 |
+|----------------------------------|------------------------|-------------------------------------------------|
+| **CSV**                          | File                   | path                                            |
+| **JSON**                         | File                   | path, record_path (opt), flatten (opt)          |
+| **Parquet**                      | File                   | path, columns (opt)                             |
+| **PostgreSQL**                   | Database               | host, port, dbname, user (—password in secrets) |
+| **Clickhouse**                   | Database               | host, port, database, user (—password in secrets) |
+| **API**                          | HTTP                   | url, (method, headers, params, auth, pagination) |
+| **Firebase (Firestore)**         | Firestore              | credentials_path, project_id, collection, mode  |
+| **Firebase (Realtime Database)** | Realtime Database      | credentials_path, project_id, path, mode        |
+
+---


### PR DESCRIPTION
Closes #527

### What’s new
- 🎉 Adds `type = "firebase"` support in `preswald.toml` for both Firestore (default) and Realtime Database.
- Implements `load_firebase_source()` in `preswald/engine/managers/data.py`:
  - Validates `credentials_path` & `project_id`
  - Branches on `mode = "firestore"` vs. `mode = "realtime"`
  - Flattens nested JSON via `pd.json_normalize(..., sep=".")`
  - Handles missing `collection` / `path` errors and invalid modes
- Introduces a `FirebaseSource` class in `DataManager.connect()` to register the DataFrame in DuckDB.
- Updates docs:
  - `docs/configuration.mdx`: example `preswald.toml` snippets
  - `docs/data‑sources.mdx`: compatibility matrix row for `firebase`

### Motivation
Many teams rely on Firebase for real‑time analytics and IoT feeds. This PR enables native, “no‑SQL” dashboards directly from Firestore or Realtime DB.