### PR TITLE
fix: prevent reloading chat after api key is set

### DIFF
--- a/frontend/src/components/widgets/ChatWidget.jsx
+++ b/frontend/src/components/widgets/ChatWidget.jsx
@@ -28,7 +28,7 @@ const ChatWidget = ({
   const [apiKey, setApiKey] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
-  const hasApiKey = useMemo(() => !!sessionStorage.getItem('openai_api_key'), []);
+  const [hasApiKey, setHasApiKey] = useState(!!sessionStorage.getItem('openai_api_key'));
 
   // Add this state to store the processed context
   const [sourceContext, setSourceContext] = useState(null);
@@ -168,7 +168,7 @@ const ChatWidget = ({
     if (apiKey.trim()) {
       sessionStorage.setItem('openai_api_key', apiKey.trim());
       setShowSettings(false);
-      window.location.reload(); // Refresh to update hasApiKey state
+      setHasApiKey(true);
     }
   };
 


### PR DESCRIPTION
prevent chat reloading when api key is set when `Save Key` button is clicked.

before:

https://github.com/user-attachments/assets/c8b17ccd-8f0e-4d7e-bac2-0323d1c4fbcc

after:

https://github.com/user-attachments/assets/2eb5ed5d-c353-4858-80d8-bfaf74b4e576

