### PR TITLE
fix(runtime): fallback to full rerun when DAG dependencies are missing

### DIFF
--- a/preswald/engine/runner.py
+++ b/preswald/engine/runner.py
@@ -143,6 +143,12 @@ class ScriptRunner:
             }
 
             affected = self._service.get_affected_components(changed_atoms)
+
+            if not changed_atoms and not affected:
+                logger.warning("[ScriptRunner] No atoms affected — falling back to full script rerun")
+                await self.run_script()
+                return
+
             self._service.force_recompute(affected)
 
             # Execute workflow with selective recompute


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to contribute to the project
title: 'fix(runtime): fallback to full rerun when DAG dependencies are missing'
labels: 'bug'
assignees: 'trevor-wilson'
---

**Related Issue**  
Fixes #698

**Description of Changes**  
This PR adds a fallback in `ScriptRunner.rerun()` to re-execute the entire script if no reactive dependencies are detected via DAG analysis. This covers top-level Preswald scripts that do not use `@workflow.atom` decorators and ensures interactivity is preserved even when DAG-based tracking is absent.

**Type of Change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] New example
- [ ] Test improvement

**Testing**  
Tested manually using two scripts:
- One without any `@workflow.atom` decorators (`slider` + `text` at top level)
- One with workflow-based atoms (slider input used to render dynamic text)

Both updated correctly:
- The first relied on full script re-execution triggered by the fallback logic
- The second used selective reruns based on DAG dependency tracking

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run my code against examples and ensured no errors
- [ ] Any dependent changes have been merged and published in downstream modules
