### PR TITLE
fix(data): preserve original column names in CSV sources

### DIFF
--- a/preswald/engine/managers/data.py
+++ b/preswald/engine/managers/data.py
@@ -185,7 +185,7 @@ class CSVSource(DataSource):
                 header=true,
                 auto_detect=true,
                 ignore_errors=true,
-                normalize_names=true,
+                normalize_names=false,
                 sample_size=-1,
                 all_varchar=true
             )


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to contribute to the project
title: 'fix(csv): disable normalize_names to preserve original column names'
labels: ''
assignees: ''
---

**Related Issue**  
Fixes #N/A (no GitHub issue created)

**Description of Changes**  
This PR updates the DuckDB `read_csv_auto` invocation in `CSVSource` to explicitly set `normalize_names=false`.  
This prevents DuckDB from automatically converting column names like `"sepal.length"` into `"sepallength"`, which was causing example scripts (e.g., `hello.py`) to fail due to mismatched column names.

![image](https://github.com/user-attachments/assets/63c40ac1-a4b8-4201-82be-fc297bf3de2b)

**Type of Change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] New example
- [ ] Test improvement

**Testing**  
Manually tested by running the unmodified `examples/iris/hello.py` script and confirming that all Plotly charts render correctly using the original column names from `iris.csv`.  

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run my code against examples and ensured no errors
- [ ] Any dependent changes have been merged and published in downstream modules
