### PR TITLE
[FEATURE] Add ability to connect via source path

### DIFF
--- a/docs/sdk/get_df.mdx
+++ b/docs/sdk/get_df.mdx
@@ -12,7 +12,7 @@ The `get_df` function retrieves data from a configured source and returns it as 
 
 ## Parameters
 
-- `source_name` (str): Name of the data source as configured in preswald.toml
+- `source_name` (str): Name of the data source as configured in preswald.toml OR a path to a file (supports CSV, Parquet, and JSON)
 - `table_name` (Optional[str]): Required for database sources, specifies which table to retrieve
 
 ## Returns
@@ -32,6 +32,9 @@ from preswald import get_df
 
 # Read entire CSV file
 customers_df = get_df('eq_csv')
+
+# Or, read specific CSV file
+customers_df = get_df('data/sample.csv')
 ```
 
 ### PostgreSQL Source

--- a/docs/sdk/query.mdx
+++ b/docs/sdk/query.mdx
@@ -13,7 +13,7 @@ The `query` function executes SQL queries against configured data sources and re
 ## Parameters
 
 - `sql` (str): SQL query to execute
-- `source_name` (str): Name of the data source as configured in preswald.toml
+- `source_name` (str): Name of the data source as configured in preswald.toml OR a path to a file (supports CSV, Parquet, and JSON)
 
 ## Returns
 
@@ -38,6 +38,9 @@ sql = """
     HAVING COUNT(*) > 5
 """
 frequent_customers = query(sql, 'eq_csv')
+
+# Or, query specific CSV file
+frequent_customers = query(sql, 'data/sample.csv')
 ```
 
 ### PostgreSQL Source


### PR DESCRIPTION
**Description of Changes**
Users can avoid the `preswald.toml` flow for files, and instead use file paths (relative to where the preswald server is run) in `query` and `get_df`. `connect` works as before.

**Type of Change**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] New example
- [ ] Test improvement

**Testing**
Ran existing uses of `get_df` and `query` in examples to confirm that behavior was identical (wether dfs were fetched from files directly or via `preswald.toml`)

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run my code against examples and ensured no errors
- [x] Any dependent changes have been merged and published in downstream modules