### PR TITLE
Replacing writing to site-packages with read check

### DIFF
--- a/preswald/main.py
+++ b/preswald/main.py
@@ -153,8 +153,10 @@ def _setup_static_files(app: FastAPI) -> BrandingManager:
     assets_dir = static_dir / "assets"
 
     # Ensure directories exist
-    os.makedirs(static_dir, exist_ok=True)
-    os.makedirs(assets_dir, exist_ok=True)
+    if os.path.isdir(assets_dir):
+        app.mount("/assets", StaticFiles(directory=assets_dir), name="assets")
+    else:
+        logging.warning(f"Assets directory not found in package: {assets_dir}")
 
     # Mount static files
     app.mount("/assets", StaticFiles(directory=assets_dir), name="assets")


### PR DESCRIPTION
**Related Issue**
Fixes #651 

**Description of Changes**
Replaces `makedirs` with `isdir` to change write-based check to read-based check for static assets

**Type of Change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] New example
- [ ] Test improvement

**Testing**
![Screenshot 2025-05-01 at 4 27 32 PM](https://github.com/user-attachments/assets/4ffb1a3c-3fc6-4b58-8ee4-40865cd17a6e)
![Screenshot 2025-05-01 at 4 27 50 PM](https://github.com/user-attachments/assets/61f45afd-ca60-421a-ae12-26ce5a09c2e3)


**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run my code against examples and ensured no errors
- [x] Any dependent changes have been merged and published in downstream modules