### PR TITLE
fix: update MemoizedComponent render logic and pass re-render flag fr…

### DIFF
--- a/frontend/src/components/DynamicComponents.jsx
+++ b/frontend/src/components/DynamicComponents.jsx
@@ -328,7 +328,7 @@ const MemoizedComponent = memo(
   (prevProps, nextProps) => {
     // Custom comparison function for memoization
     return (
-      prevProps.component.id === nextProps.component.id &&
+      !prevProps.component.shouldRender &&
       prevProps.component.value === nextProps.component.value &&
       prevProps.component.error === nextProps.component.error &&
       prevProps.index === nextProps.index

--- a/preswald/utils.py
+++ b/preswald/utils.py
@@ -255,6 +255,8 @@ def with_render_tracking(component_type: str):
                     result.value if isinstance(result, ComponentReturn) else result
                 )
 
+            component['shouldRender'] = service.should_render(component_id, component)
+
             with service.active_atom(service._workflow._current_atom):
                 if service.should_render(component_id, component):
                     logger.debug(f"[{component_type}] Created component: {component}")


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to contribute to the project
title: "fix: update MemoizedComponent render logic based on backend re-render flag"
labels: ""
assignees: ""

**Related Issue**
Fixes # (No related issue)

**Description of Changes**
- Modified the `MemoizedComponent` comparison logic to check for the `shouldRender` flag instead of performing deep comparison of component properties. This eliminates the need for unnecessary property comparisons on the frontend, simplifying the re-render decision.
- Added the assignment of the `shouldRender` flag in the `with_render_tracking` decorator to determine if a component should be rendered based on backend logic. This ensures that the frontend only triggers renders when explicitly needed by the backend.

**Type of Change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] New example
- [ ] Test improvement

**Testing**
- Verified that the frontend component `MemoizedComponent` only re-renders when the `shouldRender` flag is `true` or when relevant properties change.
- Ensured that `shouldRender` is properly assigned based on the backend logic in the `with_render_tracking` decorator.
- No regression issues observed with other components relying on memoization.

**Checklist**
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have run my code against examples and ensured no errors
- [ ] Any dependent changes have been merged and published in downstream modules
