### PR TITLE
Fix playwright dependency and add documentation for pdf export

### DIFF
--- a/docs/cli/export.mdx
+++ b/docs/cli/export.mdx
@@ -1,0 +1,80 @@
+---
+title: "preswald export"
+icon: "code"
+description: "Export your Preswald components to different formats including PDF."
+---
+
+# `preswald export`
+
+The `preswald export` command allows you to export your Preswald components and visualizations to different formats, including PDF.
+
+## Arguments
+
+- **`input_file` (str):**  
+  Path to your component file that you want to export.
+- **`output_file` (str):**  
+  Destination path for the exported file.
+
+## Options
+
+- **`format` (str):**  
+  The export format. Currently supports 'pdf'. Default is 'pdf'.
+- **`output` (str):**  
+  The output file path. Default is 'preswald_report.pdf'.
+
+## Example Usage
+
+Basic export to PDF:
+```bash
+preswald export --format pdf --output output.pdf hello.py
+```
+
+## Prerequisites
+
+Before using the export functionality, ensure you have:
+
+1. **Playwright Dependencies:**
+```bash
+pip install preswald[playwright]
+playwright install
+```
+
+2. **Running Server:**
+The export process requires a running Preswald server on port 8501. This can be started with `preswald run`.
+
+## Detailed Explanation
+
+### 1. **Server Requirements**
+
+The export process requires:
+- A running Preswald server on port 8501
+- No firewall rules blocking access to port 8501
+- No other applications using port 8501
+
+### 2. **Component Requirements**
+
+Your component should:
+- Be properly formatted
+- Render correctly in a browser
+- Have all required data and dependencies accessible
+
+### 3. **Troubleshooting**
+
+Common issues and solutions:
+
+#### Connection Refused Error
+If you see `net::ERR_CONNECTION_REFUSED`:
+- Ensure the Preswald server is running
+- Check port 8501 is available
+- Verify no firewall rules are blocking access
+
+#### Missing Dependencies
+For Playwright-related errors:
+- Install the Playwright optional dependency
+- Install browser dependencies using `playwright install`
+
+### 4. **Best Practices**
+
+- Always test component rendering in browser before export
+- Start the Preswald server before running export
+- Check server logs for troubleshooting 

--- a/preswald/utils.py
+++ b/preswald/utils.py
@@ -7,9 +7,8 @@ import re
 import sys
 from functools import wraps
 from pathlib import Path
+
 import toml
-from importlib.resources import files
-from playwright.sync_api import sync_playwright
 
 from preswald.engine.service import PreswaldService
 from preswald.interfaces.component_return import ComponentReturn
@@ -256,7 +255,7 @@ def with_render_tracking(component_type: str):
                     result.value if isinstance(result, ComponentReturn) else result
                 )
 
-            component['shouldRender'] = service.should_render(component_id, component)
+            component["shouldRender"] = service.should_render(component_id, component)
 
             with service.active_atom(service._workflow._current_atom):
                 if service.should_render(component_id, component):
@@ -289,6 +288,8 @@ def export_app_to_pdf(all_components: list[dict], output_path: str):
     if not ids_to_check:
         print("⚠️ No components found to check before export.")
         return
+
+    from playwright.sync_api import sync_playwright
 
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest>=8.3", "build", "twine", "ruff>=0.1.11", "pre-commit>=3.5.0"]
+playwright = ["playwright>=1.15.0,<2.0.0; platform_system != 'Emscripten'"]
 
 [project.scripts]
 preswald = "preswald.cli:cli"


### PR DESCRIPTION
**Description of Changes**
1. Add documentation for `preswald export` CLI command for exporting Preswald Apps as PDFs
2. Fixed playwright dependency (optional dep) in `pyproject.toml`
3. Ensured that in non-playwright installations, utils file does not break.

**Type of Change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] New example
- [ ] Test improvement

**Testing**
Tested within pyodide, using dist package. And tested on examples.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run my code against examples and ensured no errors
- [x] Any dependent changes have been merged and published in downstream modules