### PR TITLE
Clean up hello.py.template to separate display logic

### DIFF
--- a/preswald/templates/default/hello.py.template
+++ b/preswald/templates/default/hello.py.template
@@ -1,27 +1,18 @@
-from preswald import text, plotly, connect, get_df, table
 import pandas as pd
 import plotly.express as px
 
-text("# Welcome to Preswald!")
-text("This is your first app. 🎉")
-
-# Load the CSV
-connect()
-df = get_df('sample_csv')
-
-# Create a scatter plot
+df = pd.read_csv('data/sample.csv')
 fig = px.scatter(df, x='quantity', y='value', text='item',
                  title='Quantity vs. Value',
                  labels={'quantity': 'Quantity', 'value': 'Value'})
 
-# Add labels for each point
 fig.update_traces(textposition='top center', marker=dict(size=12, color='lightblue'))
-
-# Style the plot
 fig.update_layout(template='plotly_white')
 
-# Show the plot
-plotly(fig)
+# Displays
+import preswald
 
-# Show the data
-table(df)
+preswald.text("# Welcome to Preswald!")
+preswald.text("This is your first app. 🎉")
+preswald.plotly(fig)
+preswald.table(df)


### PR DESCRIPTION
* refactored `hello.py.template` to isolate Preswald display functions (`text`, `plotly`, `table`)
* moved all preswald UI calls (`text(...)`, `plotly(...)`, etc) to the bottom of the script
* switched `from preswald import ...` to just `import preswald` for clearer separation of concerns
* now all display logic goes through `preswald.<fn>` which is easier to spot, grep, and update
* avoids mixing preswald display logic with data/plot setup logic
* makes it easier to reuse or test logic without running UI display code mid-script
* fixes duplicate rendering (e.g. `text(...)` was called both directly and via `preswald.text(...)`)
* removes redundant `pd.read_csv(...)` call since `get_df('sample_csv')` already handles it via `connect()`