### PR TITLE
fix(pyodide): ensure matplotlib agg backend is set to enable figure rendering

### DIFF
--- a/frontend/src/backend/worker.js
+++ b/frontend/src/backend/worker.js
@@ -47,6 +47,15 @@ class PreswaldWorker {
                 os.chdir('/project')
             `);
 
+      // Inject matplotlibrc file to set backend
+      console.log('[Worker] Configuring matplotlib');
+      await this.pyodide.loadPackage("matplotlib");
+      await this.pyodide.runPythonAsync(`
+        with open("/matplotlibrc", "w") as f:
+          f.write("backend: agg\\n")
+        import matplotlib
+        matplotlib.use("agg")`);
+
       // Install required packages
       console.log('[Worker] Installing required packages');
       await this.pyodide.loadPackage('micropip');

--- a/preswald/engine/transformers/reactive_runtime.py
+++ b/preswald/engine/transformers/reactive_runtime.py
@@ -1445,7 +1445,6 @@ class AutoAtomTransformer(ast.NodeTransformer):
             runtime_exec = []
 
         node.body = (
-            backend_config +
             original_imports +
             runtime_imports +
             self._current_frame.generated_atoms +

--- a/preswald/engine/transformers/reactive_runtime.py
+++ b/preswald/engine/transformers/reactive_runtime.py
@@ -1180,6 +1180,39 @@ class AutoAtomTransformer(ast.NodeTransformer):
         ]
         return imports
 
+    def _has_backend_config(self, body: list[ast.stmt]) -> bool:
+        for stmt in body:
+            if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+                call = stmt.value
+                if (
+                    isinstance(call.func, ast.Attribute) and
+                    isinstance(call.func.value, ast.Name) and
+                    call.func.value.id == "matplotlib" and
+                    call.func.attr == "use"
+                ):
+                    return True
+        return False
+
+    def _build_backend_config(self) -> list[ast.stmt]:
+        """
+        Injects:
+            import matplotlib
+            matplotlib.use("agg")
+        """
+        import_stmt = ast.Import(names=[ast.alias(name="matplotlib", asname=None)])
+        use_stmt = ast.Expr(
+            value=ast.Call(
+                func=ast.Attribute(
+                    value=ast.Name(id="matplotlib", ctx=ast.Load()),
+                    attr="use",
+                    ctx=ast.Load(),
+                ),
+                args=[ast.Constant(value="agg")],
+                keywords=[],
+            )
+        )
+        return [import_stmt, use_stmt]
+
     def _build_runtime_execution(self) -> list[ast.stmt]:
         """
         Builds the AST statements required to run a Preswald script.
@@ -1433,6 +1466,10 @@ class AutoAtomTransformer(ast.NodeTransformer):
             for stmt in non_import_stmts
         )
 
+        # Check if user has explicitly set the backend
+        inject_backend = not self._has_backend_config(node.body)
+        backend_config = self._build_backend_config() if inject_backend else []
+
         # Inject the import only if needed
         should_inject_import = not (has_get_workflow_import or uses_workflow_constructor)
         runtime_imports = self._build_runtime_imports() if should_inject_import else []
@@ -1445,6 +1482,7 @@ class AutoAtomTransformer(ast.NodeTransformer):
             runtime_exec = []
 
         node.body = (
+            backend_config +
             original_imports +
             runtime_imports +
             self._current_frame.generated_atoms +


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to contribute to the project
title: 'fix(pyodide): ensure matplotlib agg backend is set to enable figure rendering'
labels: 'bug'
assignees: ''
---

**Related Issue**  
Fixes [Trello Card #2708](https://trello.com/c/4gPpK8ZX/2708-fix-matplotlib-implicit-rendering-issue-when-run-in-pyodide-show-does-not-render-anything)

**Description of Changes**  
Configures matplotlib backend in `worker.js` during Pyodide initialization.  
This approach ensures that all scripts use the `'agg'` backend by default in Pyodide, resolving figure rendering failures caused by the default `wasm_backend`.  

**Type of Change**
- [x] Bug fix (non-breaking change which fixes an issue)

**Testing**  
- Confirmed that `fig.show()` now renders correctly in Pyodide without requiring explicit backend configuration in user scripts.  
- Confirmed backend is correctly reported as `'agg'` using `matplotlib.get_backend()` in user space.

Test script:
```python
from preswald import slider, text
import matplotlib.pyplot as plt
import matplotlib
print('matplotlib backend = ' + matplotlib.get_backend())

n = slider("Pick a number", min_val=0, max_val=10, default=2)
text("Testing13 matplotlib agg backend with fig.show()")

fig, ax = plt.subplots()
ax.plot([0, 1, 2], [n**2, (n+1)**2, (n+2)**2])
fig.show()
```

Screenshot:
![image](https://github.com/user-attachments/assets/e4d60b76-3ac1-4535-979b-2ce747e12c7a)

**Checklist**
- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my own code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have made corresponding changes to the documentation  
- [x] My changes generate no new warnings  
- [x] I have run my code against examples and ensured no errors  
- [ ] Any dependent changes have been merged and published in downstream modules
