### PR TITLE
fix(websocket): avoid stale cache when loading project_fs.json

### DIFF
--- a/frontend/src/utils/websocket.js
+++ b/frontend/src/utils/websocket.js
@@ -408,7 +408,8 @@ class ComlinkClient {
       this._notifySubscribers({ type: 'connection_status', connected: true });
 
       console.log('[Client] Loading project fs');
-      const resp = await fetch('project_fs.json');
+      const resp = await fetch('project_fs.json', { cache: 'no-cache' });
+
       const raw = await resp.json();
 
       const files = {};


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to contribute to the project
title: 'fix(websocket): avoid stale cache when loading project_fs.json'
labels: 'bug'
assignees: ''
---

**Related Issue**  
Fixes https://trello.com/c/SiqJtJnH/2709-bug-fix-websocket-js-is-fetching-projectfsjson-from-disk-cache

**Description of Changes**  
Previously, `project_fs.json` was being loaded from disk cache, causing user script changes to be ignored on reload when running in Pyodide. This change sets the fetch cache mode to `'no-cache'`, allowing the browser to revalidate the file with the server and avoid serving stale data.

This appears to resolve the issue. If stale cache problems persist, we can switch to a more aggressive setting like `'no-store'`.

**Type of Change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] New example
- [ ] Test improvement

**Testing**  
Tested manually by reloading the browser in Pyodide mode and confirming that changes to the user script are now reflected correctly on page load. Verified that the response is no longer served from cache by inspecting the browser dev tools network tab.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run my code against examples and ensured no errors
- [ ] Any dependent changes have been merged and published in downstream modules
