### PR TITLE
Chore/update examples implicit rendering

### DIFF
--- a/examples/earthquakes/hello.py
+++ b/examples/earthquakes/hello.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import plotly.express as px
 
-from preswald import get_df, plotly, slider, table, text
+from preswald import get_df, slider, table, text
 
 
 # Title
@@ -62,7 +62,6 @@ table(filtered_data)
 # Summary statistics
 text(f"### Total Earthquakes with Magnitude ≥ {min_magnitude}: {len(filtered_data)}")
 
-
 # Interactive map using Plotly
 text("## Earthquake Locations")
 fig_map = px.scatter_geo(
@@ -74,13 +73,13 @@ fig_map = px.scatter_geo(
     hover_name="ID",
     title="Earthquake Map",
 )
-plotly(fig_map)
+fig_map.show()
 
 # Magnitude distribution
 fig_hist = px.histogram(
     filtered_data, x="Magnitude", nbins=20, title="Distribution of Magnitudes"
 )
-plotly(fig_hist)
+fig_hist.show()
 
 # Depth vs. Magnitude scatter plot
 fig_scatter = px.scatter(
@@ -91,4 +90,4 @@ fig_scatter = px.scatter(
     title="Depth vs Magnitude",
     labels={"Depth": "Depth (km)", "Magnitude": "Magnitude"},
 )
-plotly(fig_scatter)
+fig_scatter.show()

--- a/examples/iris/hello.py
+++ b/examples/iris/hello.py
@@ -7,19 +7,12 @@ from preswald import (
     chat,
     # fastplotlib,
     get_df,
-    plotly,
     sidebar,
     table,
     text,
 )
 
-
 sidebar()
-
-# from preswald.engine.service import PreswaldService
-
-
-# service = service = PreswaldService.get_instance()
 
 # Report Title
 text(
@@ -42,7 +35,7 @@ fig1 = px.scatter(
     labels={"sepal.length": "Sepal Length", "sepal.width": "Sepal Width"},
 )
 fig1.update_layout(template="plotly_white")
-plotly(fig1)
+fig1.show()
 
 # 2. Histogram of Sepal Length
 text(
@@ -52,7 +45,7 @@ fig3 = px.histogram(
     df, x="sepal.length", color="variety", title="Distribution of Sepal Length"
 )
 fig3.update_layout(template="plotly_white")
-plotly(fig3)
+fig3.show()
 
 # 3. Box plot of Sepal Width by Species
 text(
@@ -66,7 +59,7 @@ fig5 = px.box(
     title="Sepal Width Distribution by Species",
 )
 fig5.update_layout(template="plotly_white")
-plotly(fig5)
+fig5.show()
 
 # 4. Violin plot of Sepal Length by Species
 text(
@@ -80,7 +73,7 @@ fig7 = px.violin(
     title="Sepal Length Distribution by Species",
 )
 fig7.update_layout(template="plotly_white")
-plotly(fig7)
+fig7.show()
 
 # 5. Density contour plot - Sepal Length vs Petal Length
 text(
@@ -94,7 +87,7 @@ fig10 = px.density_contour(
     title="Density Contour of Sepal Length vs Petal Length",
 )
 fig10.update_layout(template="plotly_white")
-plotly(fig10)
+fig10.show()
 
 # # 6. Fastplotlib Examples
 #


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to contribute to the project
title: 'feat(runtime): expand implicit rendering and add reactive support for display calls'
labels: 'enhancement, runtime, reactivity'
assignees: ''

---

**Related Issue** 

tracked by: https://trello.com/c/a3cHqnsG/2718-update-examples-to-use-implicit-rendering-where-possible-and-make-needed-enhancements-to-atom-transformer

---

**Description of Changes**
This PR enhances Preswald’s reactive runtime transformer to improve support for implicit rendering, reactivity, and static analysis. While the primary focus was to enable detection of display methods (like `fig.show()` or `plt.show()`), the changes introduced a number of deeper improvements:

* **Implicit rendering for common display methods**, including `fig.show()` and `plt.show()`, through AST-based detection and lifting into reactive atoms.
* **Tuple unpacking dependency support**: correctly tracks and rewrites subscript accesses like `a, b = pair(...)` and `text(f"{a} and {b}")`.
* **Support for subscript assignment**: `arr[i] = func(...)` now lifts and tracks dependencies properly.
* **Expanded static type analysis**:

  * `auto_register_return_hints` now automatically registers return types for public functions like `subplots()` and custom helpers.
  * `get_return_type_hint` and type resolvers are used to infer outputs and guide component rendering.
* **Improved AST fallback handling**: additional guards and logging ensure that transformation fails gracefully when unexpected cases arise.
* **Simplified and reorganized registry loading** to improve readability and avoid redundant imports.
* **Corrected variable to atom mapping propagation** in various edge cases.
* **Switched logging from `info` to `debug`** to reduce log noise while retaining traceability.
* **Improved alias support** to allow module namespaces, custom import aliases and custom name aliases

**Type of Change**
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] New example
- [ ] Test improvement

**Testing**  
- Ran both the Earthquakes and iris demos successfully with implicit rendering after all updates  
- Manually validated:  
  - `fig.show()` and `plt.show()` now render without explicit registration  
  - `df.to_html()` render via return based lifting  
  - Runtime registers inline `register_*` calls correctly  
  - Complex examples using `slider()`, subscript assignment, and `text()` rerender as expected  
- Confirmed fallback to full script execution works on transformation failure

**Checklist**
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have run my code against examples and ensured no errors
- [x] Any dependent changes have been merged and published in downstream modules
