### PR TITLE
feat(errors): add runtime error reporting for reactive atoms

### DIFF
--- a/frontend/src/components/ErrorsReport.jsx
+++ b/frontend/src/components/ErrorsReport.jsx
@@ -36,6 +36,7 @@ const ErrorsReport = ({ errors }) => {
             {errors.map((err, idx) => (
               <li key={idx}>
                 <strong>{err.filename}:{err.lineno}</strong> - {err.message}
+                {err.count > 1 ? ` (x${err.count})` : null}
               </li>
             ))}
           </ul>

--- a/preswald/engine/base_service.py
+++ b/preswald/engine/base_service.py
@@ -86,7 +86,7 @@ class BasePreswaldService:
         if cls._instance is None:
             cls._instance = cls()
             if script_path:
-                cls._instance._script_path = script_path
+                cls._instance._script_path = os.path.abspath(script_path)
                 cls._instance._initialize_data_manager(script_path)
         return cls._instance
 
@@ -100,7 +100,7 @@ class BasePreswaldService:
         if not os.path.exists(path):
             raise FileNotFoundError(f"Script not found: {path}")
 
-        self._script_path = path
+        self._script_path = os.path.abspath(path)
         self._initialize_data_manager(path)
 
     @property

--- a/preswald/engine/runner.py
+++ b/preswald/engine/runner.py
@@ -213,8 +213,15 @@ class ScriptRunner:
             components = self._service.get_rendered_components()
             logger.info(f"[ScriptRunner] Rendered {len(components)} components (rerun)")
 
-            if components:
-                await self.send_message({"type": "components", "components": components})
+            errors = self._service.get_errors(filename=self.script_path)
+            message_type = "errors:result" if len(errors) else "components"
+
+            if len(components) or len(errors):
+                await self.send_message({
+                    "type": message_type,
+                    "errors": errors or [],
+                    "components": components or []
+                })
                 if logger.isEnabledFor(logging.DEBUG):
                     logger.debug(f"[ScriptRunner] Sent components to frontend {components=}")
                 else:

--- a/preswald/engine/runner.py
+++ b/preswald/engine/runner.py
@@ -406,7 +406,7 @@ class ScriptRunner:
                         logger.warning(f"[ScriptRunner] No producer atom found {component_id=}")
                         continue
 
-            errors = self._service.get_errors(type="ast_transform", filename=self.script_path)
+            errors = self._service.get_errors(filename=self.script_path)
             message_type = "errors:result" if len(errors) else "components"
 
             if (components and row_count) or len(errors):

--- a/preswald/engine/transformers/reactive_runtime.py
+++ b/preswald/engine/transformers/reactive_runtime.py
@@ -79,7 +79,7 @@ class AutoAtomTransformer(ast.NodeTransformer):
         self._used_display_renderer_fns: set[str] = set()
 
         try:
-            with open(filename, "r") as f:
+            with open(filename) as f:
                 self._source_lines = f.readlines()
         except Exception as e:
             logger.warning(f"[AST] Could not read source lines for file {filename}: {e}")

--- a/preswald/engine/transformers/reactive_runtime.py
+++ b/preswald/engine/transformers/reactive_runtime.py
@@ -483,8 +483,9 @@ class AutoAtomTransformer(ast.NodeTransformer):
             callsite_node: ast.AST | None = None,
         ) -> ast.FunctionDef:
         func = self._build_atom_function(atom_name, component_id, callsite_deps, call_expr, return_target=return_target, callsite_node=callsite_node)
-        self._finalize_atom_deps(func)
-        self._current_frame.generated_atoms.append(func)
+        if func is not None:
+            self._finalize_atom_deps(func)
+            self._current_frame.generated_atoms.append(func)
         return func
 
     def _should_inline_function(self, func_name: str) -> bool:
@@ -2482,6 +2483,8 @@ class AutoAtomTransformer(ast.NodeTransformer):
             body = call_expr
         elif isinstance(call_expr, ast.Assign) or isinstance(call_expr, ast.Expr):
             body = [call_expr]
+        elif isinstance(call_expr, ast.Call):
+            body = [ast.Expr(value=call_expr)]
         else:
             self._safe_register_error(
                 node=call_expr,

--- a/preswald/interfaces/render/error_registry.py
+++ b/preswald/interfaces/render/error_registry.py
@@ -1,5 +1,6 @@
-from threading import Lock
 import os
+from threading import Lock
+
 
 """
 Provides a simple in-memory registry for collecting and retrieving structured

--- a/preswald/interfaces/workflow.py
+++ b/preswald/interfaces/workflow.py
@@ -176,21 +176,27 @@ class Atom:
 
                 # if callsite source was not provided, attempt to
                 # capture this info where the atom was defined
-                if not callsite_source and callsite_filename:
-                    try:
-                        with open(callsite_filename, 'r') as f:
-                            lines = f.readlines()
-                            lineno = callsite_lineno or 0
-                            callsite_source = lines[lineno - 1].strip() if 0 < lineno <= len(lines) else ""
-                            self.callsite_metadata['callsite_source'] = callsite_source
+                #
+                # TODO(preswald): Centralize source line buffering per filename in the service layer.
+                # This would allow both the AST transformer and Atom class to fetch source snippets
+                # without reopening the file. Until then, skip this fallback to avoid redundant I/O.
+                #
+                # if not callsite_source and callsite_filename:
+                #     try:
+                #         with open(callsite_filename, 'r') as f:
+                #             lines = f.readlines()
+                #             lineno = callsite_lineno or 0
+                #             callsite_source = lines[lineno - 1].strip() if 0 < lineno <= len(lines) else ""
+                #             self.callsite_metadata['callsite_source'] = callsite_source
 
-                    except Exception:
-                        pass
+                #     except Exception:
+                #         pass
 
                 register_error(
                     type="runtime",
                     filename=callsite_filename or "<unknown>",
                     lineno=callsite_lineno or 0,
+                    source=callsite_source or "",
                     message=str(e),
                     atom_name=self.name,
                 )


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to contribute to the project
title: 'feat(errors): add runtime error reporting for reactive atoms'
labels: 'enhancement'
assignees: ''
---

**Related Issue**
Stacked on: https://github.com/StructuredLabs/preswald/pull/751  
Implements follow-up improvements to: feat(errors): implement error handling and reporting for AutoAtomTransformer (#751)

**Description of Changes**
This PR introduces runtime error reporting for reactive atoms.

Previously, if a reactive atom raised an exception during execution, it would only appear in the browser console or logs — there was no structured mechanism for surfacing these errors to the user or frontend. This change addresses that gap by:

- Capturing uncaught exceptions raised during atom execution (`wrapped_func`).
- Reporting the error using `register_error(...)`, including:
  - filename
  - line number
  - source line (when available)
  - atom name
  - error message
- Supporting error aggregation by count

This enables much clearer debugging and observability for user defined scripts.

**Type of Change**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] New example
- [ ] Test improvement

**Testing**
- Created example scripts that raise runtime exceptions
- Confirmed that structured error entries are reported and counted
- Verified filename, line number, and source line are included in the error payload when available
- Ensured existing atom behavior (execution and reactivity) is preserved for valid scripts

**Screenshot**
![image](https://github.com/user-attachments/assets/c269c50e-4d0c-413c-8e51-ee53192b65c0)

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run my code against examples and ensured no errors
- [x] Any dependent changes have been merged and published in downstream modules
