### PR TITLE
fix(runtime): remove incorrect callsite_hint fallback from render tracking"

### DIFF
--- a/preswald/engine/render_tracking.py
+++ b/preswald/engine/render_tracking.py
@@ -54,14 +54,6 @@ def with_render_tracking(component_type: str):
 
         @wraps(func)
         def wrapper(*args, **kwargs):
-            # Extract a callsite hint for ID generation if not explicitly provided
-            if "callsite_hint" not in kwargs:
-                stack = inspect.stack()
-                for frame in stack:
-                    if "preswald" not in frame.filename:
-                        kwargs["callsite_hint"] = f"{frame.filename}:{frame.lineno}"
-                        break
-
             # Resolve component ID and corresponding atom name
             if "component_id" in kwargs:
                 component_id = kwargs["component_id"]
@@ -69,7 +61,8 @@ def with_render_tracking(component_type: str):
                 logger.debug(f"[with_render_tracking] Using provided component_id {component_id}:{atom_name}")
             else:
                 identifier = kwargs.get("identifier")
-                component_id = generate_stable_id(component_type, callsite_hint=kwargs["callsite_hint"], identifier=identifier)
+                callsite_hint = kwargs.get("callsite_hint")
+                component_id = generate_stable_id(component_type, callsite_hint=callsite_hint, identifier=identifier)
                 atom_name = generate_stable_atom_name_from_component_id(component_id)
                 kwargs["component_id"] = component_id
                 logger.debug(f"[with_render_tracking] Generated component_id {component_id}:{atom_name}")

--- a/preswald/utils.py
+++ b/preswald/utils.py
@@ -154,11 +154,12 @@ def get_user_code_callsite(exc: BaseException | None = None, fallback: str = "un
     preswald_src_dir = os.path.abspath(os.path.join(__file__, ".."))
 
     def is_user_code(filepath: str) -> bool:
+        filepath = os.path.abspath(filepath)
         return not (
             filepath.startswith(preswald_src_dir)
-            or ".venv" in filepath
-            or "site-packages" in filepath
+            or filepath.startswith(sys.prefix)
             or filepath.startswith(sys.base_prefix)
+            or "site-packages" in filepath
         )
 
     if exc and exc.__traceback__:


### PR DESCRIPTION
Previously, `with_render_tracking` would infer a `callsite_hint` using stack inspection when none was provided, which could result in incorrect IDs from stdlib or venv code. This fallback has been removed.

Instead, `generate_stable_id` reliably falls back to `get_user_code_callsite`, which filters out venvs and site-packages using absolute path prefixes.

This ensures that lifted components without explicit callsite_hint receive stable and user script IDs.

---
name: Pull Request  
about: Create a pull request to contribute to the project  
title: "fix(runtime): remove incorrect callsite_hint fallback from render tracking"  
labels: bug  
assignees: ''

---

**Related Issue**  
Fixes https://trello.com/c/xC7FmqS9/2742-preswald-render-tracking-callsitehint-fallback-resolves-incorrect-callsite-throug-stack-inspection

**Description of Changes**  
- Removed stack based fallback for `callsite_hint` inside `with_render_tracking`.
- Enhanced `is_user_code()` to filter out all files within the active venv and site-packages using absolute paths via `sys.prefix` and `sys.base_prefix`.

**Type of Change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] New example
- [ ] Test improvement

**Testing**  
- Manually verified that user defined scripts produce consistent and correct `component_id`s when `callsite_hint` is omitted.
- Confirmed that fallback callsite no longer resolves to standard library paths, such as `asyncio/events.py`, in the generated output.

**Checklist**
- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my own code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have made corresponding changes to the documentation  
- [x] My changes generate no new warnings  
- [x] I have run my code against examples and ensured no errors  
- [ ] Any dependent changes have been merged and published in downstream modules  
