### PR TITLE
fix(ast): inject missing component_id into known component calls

### DIFF
--- a/preswald/engine/transformers/reactive_runtime.py
+++ b/preswald/engine/transformers/reactive_runtime.py
@@ -1539,6 +1539,16 @@ class AutoAtomTransformer(ast.NodeTransformer):
                             logger.debug(f"[AST] Missing atom mapping for {full_func_name=}. Regenerating...")
                         component_id, atom_name = self.generate_component_and_atom_name(full_func_name, stmt)
 
+                    # Inject component_id into the call AST node if not already present
+                    if isinstance(call_node, ast.Call):
+                        already_has_id = any(kw.arg == "component_id" for kw in call_node.keywords)
+                        if not already_has_id:
+                            call_node.keywords.append(ast.keyword(
+                                arg="component_id",
+                                value=ast.Constant(value=component_id)
+                            ))
+                            logger.debug(f"[AST] Injected component_id='{component_id}' into call '{full_func_name}'")
+
                     if self._uses_known_atoms(stmt):
                         self._lift_consumer_stmt(stmt)
                     else:


### PR DESCRIPTION
Previously, known component calls lifted via _lift_statements could omit the `component_id` keyword in the AST if routed through `_lift_consumer_stmt`. This led to inconsistent component identity and diffing issues.

This change ensures that all known component calls receive a stable `component_id` argument before being lifted, regardless of path taken.

---
name: Pull Request  
about: Create a pull request to contribute to the project  
title: 'fix(ast): inject missing component_id into known component calls'  
labels: 'bug'  
assignees: ''

**Related Issue**  
Fixes https://trello.com/c/jmU7tAXj/2743-preswald-consumer-components-do-not-inject-componentid-after-being-lifted-causing-fallback-to-infer-the-correct-componentid

**Description of Changes**  
- Injects `component_id` into known component calls in `_lift_statements`, even when they are routed through `_lift_consumer_stmt`.
- Ensures consistent and stable component identity for all lifted components.
- Prevents downstream issues related to backend component and frontend widget identity differences.

**Type of Change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] New example
- [ ] Test improvement

**Testing**  
- Verified that `component_id` is injected into lifted component calls for both consumer and non-consumer paths.
- Confirmed consistent `component_id` hashing and matching between frontend rendered components and atom-wrapped callsites.
- Manually tested against example scripts including consumer components with reactive dependencies.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run my code against examples and ensured no errors
- [ ] Any dependent changes have been merged and published in downstream modules
