### PR TITLE
fix(chat): restore AI responses by passing correct id to ChatWidget

### DIFF
--- a/frontend/src/components/DynamicComponents.jsx
+++ b/frontend/src/components/DynamicComponents.jsx
@@ -275,8 +275,8 @@ const MemoizedComponent = memo(
             value={component.value || component.state || { messages: [] }}
             onChange={(value) => {
               handleUpdate(componentId, value);
-              id = { componentId };
             }}
+            id={componentId}
           />
         );
 


### PR DESCRIPTION
The `id` prop was not being passed to the ChatWidget and was accidentally misplaced in the `onChange` handler, causing an assignment to an undeclared identifier. This runtime error silently broke the chat widget and prevented the AI from responding to user prompts.

---
name: Pull Request  
about: Create a pull request to contribute to the project  
title: 'fix(chat): restore AI responses by passing correct id to ChatWidget'  
labels: 'bug'  
assignees: ''  
---

**Related Issue**  
Fixes https://trello.com/c/PuXU7sVc/2744-preswald-chatwidget-onchange-error-breaks-communication-with-ai

**Description of Changes**  
- Replaced incorrect line `id = { componentId };` with `id={componentId}` in the ChatWidget instantiation  
- This ensures the `ChatWidget` receives the `id` prop, enabling proper runtime error handling and component tracking  
- Resolves a runtime error that prevented the AI from responding to user messages  

**Type of Change**  
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [ ] New example  
- [ ] Test improvement  

**Testing**  
- Verified the fix locally by triggering the chat component with and without valid AI input  
- Confirmed AI now responds as expected  

Before fix:
![image](https://github.com/user-attachments/assets/b53ca57b-9c13-4a4c-831d-862938cc3cea)


After fix:
![image](https://github.com/user-attachments/assets/d45bdf1f-a817-4f60-bf94-0d22802a7cc3)


**Checklist**  
- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my own code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have made corresponding changes to the documentation  
- [x] My changes generate no new warnings  
- [x] I have run my code against examples and ensured no errors  
- [ ] Any dependent changes have been merged and published in downstream modules