### PR TITLE
resolved the issue to export app, it requred --format argument which …

### DIFF
--- a/preswald/cli.py
+++ b/preswald/cli.py
@@ -382,7 +382,7 @@ def tutorial(ctx):
 @click.option(
     "--format",
     type=click.Choice(["pdf", "html"]),
-    required=True,
+    default="html",
     help="Export format - pdf creates a static report, html creates an interactive web app",
 )
 @click.option("--output", type=click.Path(), help="Path to the output directory")


### PR DESCRIPTION
name: Noor Nabi
about: Fix to buid app as html by default and if pdf needs to be generated --format pdf should be called in the export command
title: fix/build-script
labels: bug
assignees: ''
---

**Related Issue**
Fixes #(issue)

**Description of Changes**
A clear and concise description of the changes made in this pull request.

**Type of Change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] New example
- [ ] Test improvement

**Testing**
Please describe the tests that you ran to verify your changes. Include screenshots/videos.
![image](https://github.com/user-attachments/assets/ef344953-2d09-435e-b1d7-c7066e07b9b4)
The above image shows a successful export for earthquake example
**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run my code against examples and ensured no errors
- [x] Any dependent changes have been merged and published in downstream modules