### PR TITLE
fix: local log error (not found) fix

### DIFF
--- a/autotest/deployments/local/test.sh
+++ b/autotest/deployments/local/test.sh
@@ -65,6 +65,8 @@ test_example() {
         return 1
     }
     
+    local log_file="local_deployment_test.log"
+    
     log "INFO" "Deploying locally..." "$log_file"
     start_time=$(date +%s)
     


### PR DESCRIPTION
Issue: shell test script doesn't alter log_file variable after changing directory, leading to this error

![Screenshot 2025-06-30 175828](https://github.com/user-attachments/assets/decf69c4-9330-4104-9294-44f39dcca11f)

Fix: after cd command, reset log_file variable to local relative location within each directory
