### PR TITLE
fix: prevent reloading chat widget after adding api key

### DIFF
--- a/frontend/src/components/widgets/ChatWidget.jsx
+++ b/frontend/src/components/widgets/ChatWidget.jsx
@@ -29,7 +29,8 @@ const ChatWidget = ({
   const [apiKey, setApiKey] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
-  const hasApiKey = useMemo(() => !!sessionStorage.getItem('openai_api_key'), []);
+  
+  const [hasApiKey, setHasApiKey] = useState(!!sessionStorage.getItem('openai_api_key'));
 
   // Add this state to store the processed context
   const [sourceContext, setSourceContext] = useState(null);
@@ -169,7 +170,8 @@ const ChatWidget = ({
     if (apiKey.trim()) {
       sessionStorage.setItem('openai_api_key', apiKey.trim());
       setShowSettings(false);
-      window.location.reload(); // Refresh to update hasApiKey state
+
+      setHasApiKey(true);
     }
   };
 


### PR DESCRIPTION
prevent reloading of ChatWidget after adding api key.


before:

https://github.com/user-attachments/assets/c8b17ccd-8f0e-4d7e-bac2-0323d1c4fbcc

after:

https://github.com/user-attachments/assets/2eb5ed5d-c353-4858-80d8-bfaf74b4e576


