### PR TITLE
fix (build) : Fixes build error due to 2GB default memory allocation to v8 engine (nodejs)

### DIFF
--- a/preswald/build.py
+++ b/preswald/build.py
@@ -1,9 +1,14 @@
 """Build utilities for preswald."""
 
+import os
 import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+
+env = os.environ.copy()
+env["NODE_OPTIONS"] = env.get("NODE_OPTIONS", "--max-old-space-size=4096")
 
 
 def _run_npm_command(cmd: str, cwd: Path) -> int:

--- a/preswald/build.py
+++ b/preswald/build.py
@@ -18,7 +18,7 @@ def _run_npm_command(cmd: str, cwd: Path) -> int:
         print("Error: npm not found. Please install npm first.", file=sys.stderr)
         return 1
 
-    result = subprocess.run([npm_path, *cmd.split()], cwd=cwd, check=False)
+    result = subprocess.run([npm_path, *cmd.split()], cwd=cwd, check=False, env=env)
     return result.returncode
 
 


### PR DESCRIPTION
**Related Issue**
Fixes #775 


**Description of Changes**
I ran into the issue of not being able to build the repository for testing a few days back for which I myself added this issue to the issue board.
I tried to fix this issue on my own and realized that it was a nodejs issue. v8 engine by default has a cap of 2 GB which was overflowing and I added the NODE_OPTIONS to increase the assigned memory for that particular subprocess.

**Type of Change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] New example
- [ ] Test improvement

**Testing**
I initially ran the build process which lead to it being failed.
<img width="1920" height="827" alt="image" src="https://github.com/user-attachments/assets/c203a1d3-67ec-42f9-8866-5c1029c9b0e9" />
After checking the nodejs memory usage the issue was apparent and I went on to globally set the memory assigned to nodejs 4gb which fixed the issue.
After setting the environment variable there is a layer of abstraction that a new contributor doesn`t have to face to contribute.

**Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run my code against examples and ensured no errors
- [x] Any dependent changes have been merged and published in downstream modules