### PR TITLE
fix: cap generated container name to GCP Cloud Run's service-id limit

### DIFF
--- a/preswald/deploy.py
+++ b/preswald/deploy.py
@@ -29,6 +29,12 @@ def get_deploy_dir(script_path: str) -> Path:
     return deploy_dir
 
 
+# Google Cloud Run rejects service names of 50 characters or more
+# (`CreateServiceRequest.service_id`), so the generated container name must
+# stay under that limit even after the "preswald-app-" prefix is added.
+GCP_SERVICE_NAME_MAX_LENGTH = 49
+
+
 def get_container_name(script_path: str) -> str:
     """Generate a consistent container name for a given script"""
     script_dir = Path(script_path).parent
@@ -39,6 +45,7 @@ def get_container_name(script_path: str) -> str:
     container_name = container_name.lower()
     container_name = re.sub(r"[^a-z0-9-]", "", container_name)
     container_name = container_name.strip("-")
+    container_name = container_name[:GCP_SERVICE_NAME_MAX_LENGTH].rstrip("-")
     return container_name
 
 

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1,0 +1,41 @@
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from preswald.deploy import GCP_SERVICE_NAME_MAX_LENGTH, get_container_name
+
+
+def _write_toml_project(tmp_path: Path, slug: str) -> Path:
+    script_path = tmp_path / "hello.py"
+    script_path.write_text("")
+    (tmp_path / "preswald.toml").write_text(
+        f'[project]\nslug = "{slug}"\nport = 8501\n'
+    )
+    return script_path
+
+
+def test_get_container_name_stays_under_gcp_limit():
+    # A long-but-valid project slug used to produce a container name past
+    # Cloud Run's <50 char service_id limit once the "preswald-app-" prefix
+    # was added, causing `CreateServiceRequest.service_id` violations (#659).
+    long_slug = "a-very-descriptive-project-slug-for-an-org-1744321134"
+    with tempfile.TemporaryDirectory() as tmp:
+        script_path = _write_toml_project(Path(tmp), long_slug)
+        container_name = get_container_name(str(script_path))
+
+    assert len(container_name) <= GCP_SERVICE_NAME_MAX_LENGTH
+    assert not container_name.endswith("-")
+    assert container_name.startswith("preswald-app-")
+
+
+def test_get_container_name_short_slug_unaffected():
+    with tempfile.TemporaryDirectory() as tmp:
+        script_path = _write_toml_project(Path(tmp), "zwbq")
+        container_name = get_container_name(str(script_path))
+
+    assert container_name == "preswald-app-zwbq"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What was the bug

Deploying to GCP fails with a 500, and the underlying API response is:

```json
{"error": "400 Violation in CreateServiceRequest.service_id: only lowercase, digits, and hyphens; must begin with letter, and cannot end with hyphen; must be less than 50 characters. ..."}
```

## Root cause

`get_container_name()` in `preswald/deploy.py` builds the Cloud Run service name as `preswald-app-{slug}`, sanitizes the character set, and then hands it straight to `gcloud run deploy <container_name>` / Cloud Run's `CreateService` API — with **no length cap**.

Google Cloud Run rejects `service_id` values of 50 characters or more. The `"preswald-app-"` prefix alone is 13 characters, so any project slug that pushes the combined name to 50+ characters triggers exactly the quoted violation. This surfaces to the user as an opaque 500 during deploy, with the real cause several layers removed from the actual GCP validation error.

## What the fix does

Truncates the sanitized container name to 49 characters (Cloud Run's limit is "less than 50"), stripping any trailing hyphen left by the cut. Short slugs are completely unaffected.

```python
GCP_SERVICE_NAME_MAX_LENGTH = 49
...
container_name = container_name[:GCP_SERVICE_NAME_MAX_LENGTH].rstrip("-")
```

## How to reproduce / verify

```python
import re

def build_container_name(slug, cap):
    name = f"preswald-app-{slug}".lower()
    name = re.sub(r"[^a-z0-9-]", "", name).strip("-")
    if cap:
        name = name[:49].rstrip("-")
    return name

long_slug = "a-very-descriptive-project-slug-for-an-org-1744321134"

before = build_container_name(long_slug, cap=False)
after = build_container_name(long_slug, cap=True)

assert len(before) == 66   # >= 50 -> violates GCP's constraint, reproduces #659
assert len(after) == 48    # now within the limit
```

Added `tests/test_deploy.py` with regression tests covering:
- a long project slug, asserting the generated container name stays at or under 49 characters and doesn't end in a hyphen
- a short project slug (`zwbq`, matching the slug format in the original report), asserting it's byte-for-byte unaffected by the change

## Note

The report in #659 was against the hosted `app.preswald.com` deploy flow rather than the local `preswald deploy --target gcp` path, and I don't have visibility into that hosted backend's source. However, the error message is GCP Cloud Run's literal `CreateServiceRequest.service_id` validation response, and this is the only place in the OSS codebase that constructs a Cloud Run service name from a project slug with no length bound — the exact same violation reproduces from this code with a sufficiently long slug. If the hosted backend uses different naming logic, happy to adjust scope once that's clarified.

Fixes #659